### PR TITLE
Workaround bundler issue which could cause an old extension to get used.

### DIFF
--- a/lib/liquid/c.rb
+++ b/lib/liquid/c.rb
@@ -1,6 +1,14 @@
 require 'liquid/c/version'
 require 'liquid'
-require 'liquid_c'
+
+# workaround bundler issue #2947 which could cause an old extension to be used
+require 'rbconfig'
+ext_path = File.expand_path("../../liquid_c.#{RbConfig::CONFIG['DLEXT']}", __FILE__)
+if File.exists?(ext_path)
+  require ext_path
+else
+  require 'liquid_c'
+end
 
 Liquid::Template.class_eval do
   private


### PR DESCRIPTION
@csfrancis & @arthurnn for review
## Problem

See issue https://github.com/bundler/bundler/issues/2947
## Solution

Try to load liquid_c.bundle by absolute path if it can be found relative to lib/liquid/c.rb, since that ruby file will be in a directory that is properly versioned by the git sha (e.g. ~/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/bundler/gems/liquid-c-8a8cb9579934/lib).
