### PR TITLE
Initialize all fields of zero token before returning it.

### DIFF
--- a/ext/liquid_c/parser.c
+++ b/ext/liquid_c/parser.c
@@ -34,8 +34,7 @@ lexer_token_t parser_must_consume(parser_t *p, unsigned char type)
 lexer_token_t parser_consume(parser_t *p, unsigned char type)
 {
     if (p->cur.type != type) {
-        lexer_token_t zero;
-        zero.type = 0;
+        lexer_token_t zero = {0};
         return zero;
     }
     return parser_consume_any(p);


### PR DESCRIPTION
@pushrax for review
## Problem

I was getting the following compilation error when trying to compile the gem on Mac OS X (I guess llvm complains about this but not gcc

```
parser.c: In function ‘parser_consume’:
parser.c:39: warning: ‘zero.val_end’ is used uninitialized in this function
parser.c:39: warning: ‘zero.val’ is used uninitialized in this function
parser.c:39: warning: ‘zero.flags’ is used uninitialized in this function
make: *** [parser.o] Error 1
```

This isn't currently a bug, since we were only using the `type` field in the only call site for `parser_consume`
## Solution

Zero initializing all the fields in the struct avoids this compilation issue.
