### PR TITLE
Use C strict parser externally

### DIFF
--- a/ext/liquid_c/parser.c
+++ b/ext/liquid_c/parser.c
@@ -163,6 +163,20 @@ VALUE parse_expression(parser_t *p)
     return Qnil;
 }
 
+static VALUE rb_parse_expression(VALUE self, VALUE markup)
+{
+    StringValue(markup);
+    char *start = RSTRING_PTR(markup);
+
+    parser_t p;
+    init_parser(&p, start, start + RSTRING_LEN(markup));
+
+    if (p.cur.type == TOKEN_EOS)
+        return Qnil;
+
+    return parse_expression(&p);
+}
+
 void init_liquid_parser(void)
 {
     idToI = rb_intern("to_i");
@@ -173,5 +187,8 @@ void init_liquid_parser(void)
     cLiquidRangeLookup = rb_const_get(mLiquid, rb_intern("RangeLookup"));
     cRange = rb_const_get(rb_cObject, rb_intern("Range"));
     cLiquidVariableLookup = rb_const_get(mLiquid, rb_intern("VariableLookup"));
+
+    VALUE cLiquidExpression = rb_const_get(mLiquid, rb_intern("Expression"));
+    rb_define_singleton_method(cLiquidExpression, "c_parse", rb_parse_expression, 1);
 }
 

--- a/lib/liquid/c.rb
+++ b/lib/liquid/c.rb
@@ -67,3 +67,21 @@ Liquid::VariableLookup.class_eval do
     end
   end
 end
+
+Liquid::Expression.class_eval do
+  class << self
+    alias_method :ruby_parse, :parse
+
+    def parse(markup)
+      return nil unless markup
+
+      if Liquid::C.enabled
+        begin
+          return c_parse(markup)
+        rescue Liquid::SyntaxError
+        end
+      end
+      ruby_parse(markup)
+    end
+  end
+end


### PR DESCRIPTION
The strict parser was already written – this exposes it to Ruby and uses it to speed up `Expression.parse`, falling back to the original in the case of bad syntax.

Improvement:

```
ruby -----------------------------------
              parse:       37.9 (±18.5%) i/s -       1083 in  30.035048s
        parse & run:       20.4 (±14.7%) i/s -        582 in  30.056232s

master ---------------------------------
              parse:       68.0 (±19.1%) i/s -       1938 in  30.055672s
        parse & run:       27.8 (±18.0%) i/s -        798 in  30.038484s

expression-parsing ---------------------
              parse:       82.1 (±19.5%) i/s -       2331 in  29.944101s
        parse & run:       32.9 (±15.2%) i/s -        950 in  30.044010s
```

@Shopify/liquid
