### PR TITLE
Ensure Expression.parse matched the entire markup

### DIFF
--- a/ext/liquid_c/lexer.c
+++ b/ext/liquid_c/lexer.c
@@ -74,8 +74,10 @@ const char *lex_one(const char *start, const char *end, lexer_token_t *token)
 
     while (str < end && ISSPACE(*str)) ++str;
 
-    if (str >= end) return str;
+    token->val = token->val_end = NULL;
     token->flags = 0;
+
+    if (str >= end) return str;
 
     char c = *str;  // First character of the token.
     char cn = '\0'; // Second character if available, for lookahead.

--- a/ext/liquid_c/parser.c
+++ b/ext/liquid_c/parser.c
@@ -153,7 +153,7 @@ VALUE parse_expression(parser_t *p)
         }
     }
 
-    if (p->cur.type != TOKEN_EOS) {
+    if (p->cur.type == TOKEN_EOS) {
         rb_raise(cLiquidSyntaxError, "[:%s] is not a valid expression", symbol_names[p->cur.type]);
     } else {
         rb_raise(cLiquidSyntaxError, "[:%s, \"%.*s\"] is not a valid expression",


### PR DESCRIPTION
Implements the behaviour in the tests at https://github.com/Shopify/liquid/pull/480 by ensuring a syntax error is raised so it can fall back.
