### PR TITLE
Enable -Wextra

### DIFF
--- a/ext/liquid_c/extconf.rb
+++ b/ext/liquid_c/extconf.rb
@@ -1,5 +1,5 @@
 require 'mkmf'
-$CFLAGS << ' -Wall -Werror'
+$CFLAGS << ' -Wall -Werror -Wextra -Wno-unused-parameter -Wno-missing-field-initializers'
 compiler = RbConfig::MAKEFILE_CONFIG['CC']
 if ENV['DEBUG'] == 'true' && compiler =~ /gcc|g\+\+/
   $CFLAGS << ' -fbounds-check'

--- a/liquid-c.gemspec
+++ b/liquid-c.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'liquid', '~> 3.0.0'
+  spec.add_dependency 'liquid', '>= 3.0.0'
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Probably fixes #20. I enabled -Wextra to first reproduce the warning, then added -Wno-unused-parameter to suppress it and -Wno-missing-field-initializers to suppress warnings about initializing structs with `{0}`.