### PR TITLE
Tokenizer inside Liquid::C

### DIFF
--- a/ext/liquid_c/liquid.c
+++ b/ext/liquid_c/liquid.c
@@ -5,13 +5,14 @@
 #include "parser.h"
 #include "block.h"
 
-VALUE mLiquid, cLiquidSyntaxError, cLiquidVariable, cLiquidTemplate;
+VALUE mLiquid, mLiquidC, cLiquidSyntaxError, cLiquidVariable, cLiquidTemplate;
 rb_encoding *utf8_encoding;
 
 void Init_liquid_c(void)
 {
     utf8_encoding = rb_utf8_encoding();
     mLiquid = rb_define_module("Liquid");
+    mLiquidC = rb_define_module_under(mLiquid, "C");
     cLiquidSyntaxError = rb_const_get(mLiquid, rb_intern("SyntaxError"));
     cLiquidVariable = rb_const_get(mLiquid, rb_intern("Variable"));
     cLiquidTemplate = rb_const_get(mLiquid, rb_intern("Template"));

--- a/ext/liquid_c/liquid.h
+++ b/ext/liquid_c/liquid.h
@@ -5,7 +5,7 @@
 #include <ruby/encoding.h>
 #include <stdbool.h>
 
-extern VALUE mLiquid, cLiquidSyntaxError, cLiquidVariable, cLiquidTemplate;
+extern VALUE mLiquid, mLiquidC, cLiquidSyntaxError, cLiquidVariable, cLiquidTemplate;
 extern rb_encoding *utf8_encoding;
 
 #endif

--- a/ext/liquid_c/tokenizer.c
+++ b/ext/liquid_c/tokenizer.c
@@ -131,7 +131,7 @@ static VALUE tokenizer_shift_method(VALUE self)
 
 void init_liquid_tokenizer()
 {
-    cLiquidTokenizer = rb_define_class_under(mLiquid, "Tokenizer", rb_cObject);
+    cLiquidTokenizer = rb_define_class_under(mLiquidC, "Tokenizer", rb_cObject);
     rb_define_alloc_func(cLiquidTokenizer, tokenizer_allocate);
     rb_define_method(cLiquidTokenizer, "initialize", tokenizer_initialize_method, 1);
     rb_define_method(cLiquidTokenizer, "shift", tokenizer_shift_method, 0);

--- a/lib/liquid/c.rb
+++ b/lib/liquid/c.rb
@@ -19,7 +19,7 @@ Liquid::Template.class_eval do
 
   def tokenize(source)
     if Liquid::C.enabled && !@line_numbers
-      Liquid::Tokenizer.new(source.to_s)
+      Liquid::C::Tokenizer.new(source.to_s)
     else
       ruby_tokenize(source)
     end

--- a/test/unit/tokenizer_test.rb
+++ b/test/unit/tokenizer_test.rb
@@ -33,7 +33,7 @@ class TokenizerTest < MiniTest::Unit::TestCase
   private
 
   def tokenize(source)
-    tokenizer = Liquid::Tokenizer.new(source)
+    tokenizer = Liquid::C::Tokenizer.new(source)
     tokens = []
     while t = tokenizer.shift
       tokens << t


### PR DESCRIPTION
@dylanahsmith Is this what you had in mind in your comment [here](https://github.com/Shopify/liquid/pull/590#discussion_r31670239) regarding defining Tokenizer such that it doesn't conflict with ruby `Liquid::Tokenizer` until it supports line numbers? cc @pushrax 