### PR TITLE
Implement line numbers support.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gemspec
 
 gem 'liquid', github: 'Shopify/liquid', branch: 'master'
 
+
 group :test do
   gem 'spy', '0.4.1'
   gem 'benchmark-ips'

--- a/ext/liquid_c/block.c
+++ b/ext/liquid_c/block.c
@@ -11,7 +11,8 @@ static ID
     intern_clear,
     intern_tags,
     intern_parse,
-    intern_square_brackets;
+    intern_square_brackets,
+    intern_set_line_number;
 
 static int is_id(int c)
 {
@@ -34,6 +35,9 @@ static VALUE rb_block_parse(VALUE self, VALUE tokens, VALUE options)
     VALUE nodelist = rb_ivar_get(self, intern_nodelist);
 
     while (true) {
+        if (tokenizer->line_number != 0) {
+            rb_funcall(options, intern_set_line_number, 1, UINT2NUM(tokenizer->line_number));
+        }
         tokenizer_next(tokenizer, &token);
 
         switch (token.type) {
@@ -115,6 +119,7 @@ void init_liquid_block()
     intern_tags = rb_intern("tags");
     intern_parse = rb_intern("parse");
     intern_square_brackets = rb_intern("[]");
+    intern_set_line_number = rb_intern("line_number=");
 
     VALUE cLiquidBlockBody = rb_const_get(mLiquid, rb_intern("BlockBody"));
     rb_define_method(cLiquidBlockBody, "c_parse", rb_block_parse, 2);

--- a/ext/liquid_c/tokenizer.c
+++ b/ext/liquid_c/tokenizer.c
@@ -48,6 +48,8 @@ static VALUE tokenizer_initialize_method(VALUE self, VALUE source, VALUE line_nu
     tokenizer->source = source;
     tokenizer->cursor = RSTRING_PTR(source);
     tokenizer->length = RSTRING_LEN(source);
+    // tokenizer->line_number keeps track of the current line number or it is 0
+    // to indicate that line numbers aren't being calculated
     tokenizer->line_number = RTEST(line_numbers) ? 1 : 0;
     return Qnil;
 }

--- a/ext/liquid_c/tokenizer.h
+++ b/ext/liquid_c/tokenizer.h
@@ -19,6 +19,7 @@ typedef struct tokenizer {
     VALUE source;
     const char *cursor;
     long length;
+    unsigned int line_number;
 } tokenizer_t;
 
 extern VALUE cLiquidTokenizer;

--- a/lib/liquid/c.rb
+++ b/lib/liquid/c.rb
@@ -18,8 +18,8 @@ Liquid::Template.class_eval do
   alias_method :ruby_tokenize, :tokenize
 
   def tokenize(source)
-    if Liquid::C.enabled && !@line_numbers
-      Liquid::C::Tokenizer.new(source.to_s)
+    if Liquid::C.enabled
+      Liquid::C::Tokenizer.new(source.to_s, @line_numbers)
     else
       ruby_tokenize(source)
     end
@@ -30,7 +30,7 @@ Liquid::BlockBody.class_eval do
   alias_method :ruby_parse, :parse
 
   def parse(tokens, options)
-    if Liquid::C.enabled && !options[:line_numbers] && !options[:profile]
+    if Liquid::C.enabled && !options[:profile]
       c_parse(tokens, options) { |t, m| yield t, m }
     else
       ruby_parse(tokens, options) { |t, m| yield t, m }

--- a/lib/liquid/c.rb
+++ b/lib/liquid/c.rb
@@ -43,7 +43,7 @@ Liquid::Variable.class_eval do
   alias_method :ruby_strict_parse, :strict_parse
 
   def lax_parse(markup)
-    stats = @options[:stats_callbacks]
+    stats = options[:stats_callbacks]
     stats[:variable_parse].call if stats
 
     if Liquid::C.enabled

--- a/test/unit/tokenizer_test.rb
+++ b/test/unit/tokenizer_test.rb
@@ -33,7 +33,7 @@ class TokenizerTest < MiniTest::Unit::TestCase
   private
 
   def tokenize(source)
-    tokenizer = Liquid::C::Tokenizer.new(source)
+    tokenizer = Liquid::C::Tokenizer.new(source, false)
     tokens = []
     while t = tokenizer.shift
       tokens << t

--- a/test/unit/variable_test.rb
+++ b/test/unit/variable_test.rb
@@ -84,16 +84,20 @@ class VariableTest < MiniTest::Unit::TestCase
       variable_fallback: lambda { variable_fallbacks += 1 }
     }
 
-    Liquid::Variable.new('abc', error_mode: :lax, stats_callbacks: callbacks)
+    create_variable('abc', error_mode: :lax, stats_callbacks: callbacks)
     assert_equal 1, variable_parses
     assert_equal 0, variable_fallbacks
 
-    Liquid::Variable.new('@!#', error_mode: :lax, stats_callbacks: callbacks)
+    create_variable('@!#', error_mode: :lax, stats_callbacks: callbacks)
     assert_equal 2, variable_parses
     assert_equal 1, variable_fallbacks
   end
 
   private
+
+  def create_variable(markup, options={})
+    Liquid::Variable.new(markup, Liquid::ParseContext.new(options))
+  end
 
   def variable_parse(markup)
     name = Liquid::Variable.c_strict_parse(markup, filters = [])


### PR DESCRIPTION
@pushrax for review

Depends on https://github.com/Shopify/liquid/pull/614

Implement line number calculation in the liquid extension so that we don't need to fallback to ruby liquid when using the `line_numbers: true` option.