### PR TITLE
Monkey patch Liquid::Tokenizer.new instead of Liquid::Template#tokenize

### DIFF
--- a/lib/liquid/c.rb
+++ b/lib/liquid/c.rb
@@ -12,16 +12,12 @@ module Liquid
   end
 end
 
-Liquid::Template.class_eval do
-  private
-
-  alias_method :ruby_tokenize, :tokenize
-
-  def tokenize(source)
+Liquid::Tokenizer.class_eval do
+  def self.new(source, line_numbers = false)
     if Liquid::C.enabled
-      Liquid::C::Tokenizer.new(source.to_s, @line_numbers)
+      Liquid::C::Tokenizer.new(source.to_s, line_numbers)
     else
-      ruby_tokenize(source)
+      super
     end
   end
 end


### PR DESCRIPTION
@pushrax for review

Now that tokenizer has its own class, we can override Liquid::Tokenizer.new instead of the private Template method.  This also makes it easier to use the Liquid::Tokenizer and Liquid::Document directly as we have started doing in Shopify.