### PR TITLE
Allow variable and tag end characters to be quoted.

### DIFF
--- a/test/unit/tokenizer_test.rb
+++ b/test/unit/tokenizer_test.rb
@@ -30,6 +30,19 @@ class TokenizerTest < MiniTest::Unit::TestCase
     assert_equal [source], output
   end
 
+  def test_quoted_strings
+    assert_equal ['{% assign foo = "%}" %}'], tokenize('{% assign foo = "%}" %}')
+    assert_equal ["{%assign foo = '%}'%}"], tokenize("{%assign foo = '%}'%}")
+    assert_equal ['{{ "}}" }}'], tokenize('{{ "}}" }}')
+    assert_equal ["{{'}}'}}"], tokenize("{{'}}'}}")
+  end
+
+  def test_unterminated_quotes
+    assert_equal ['{% assign foo = " %}'], tokenize('{% assign foo = " %}')
+    assert_equal ['{{ " }}'], tokenize('{{ " }}')
+    assert_equal ["{{'}}"], tokenize("{{'}}")
+  end
+
   private
 
   def tokenize(source)


### PR DESCRIPTION
@pushrax & @trishume for review

For issue https://github.com/Shopify/liquid/pull/623

## Problem

https://github.com/Shopify/liquid/pull/170 tried to allow curly braces in variables, but was rejected for performance reasons.  However, parsing is a lot faster now that we are using liquid-c, so I think I don't think performance would be as much of a concern now.

## Solution

When encountering a quote character inside a variable or tag, the tokenizer will include everything up to the end quote character (if one is present) even if it includes the tag/variable end characters.