### PR TITLE
Don't allow identifiers to end in a dash in strict parse mode.

### DIFF
--- a/ext/liquid_c/lexer.c
+++ b/ext/liquid_c/lexer.c
@@ -134,6 +134,7 @@ const char *lex_one(const char *start, const char *end, lexer_token_t *token)
     if (ISALPHA(c) || c == '_') {
         cur = str;
         while (++cur < end && is_identifier(*cur)) {}
+        if (*(cur - 1) == '-') cur--;
         if (cur < end && *cur == '?') cur++;
         RETURN_TOKEN(TOKEN_IDENTIFIER, cur - str);
     }

--- a/test/unit/variable_test.rb
+++ b/test/unit/variable_test.rb
@@ -19,6 +19,7 @@ class VariableTest < MiniTest::Unit::TestCase
     assert_raises(Liquid::SyntaxError) { variable_parse('question?mark') }
     assert_raises(Liquid::SyntaxError) { variable_parse('123.foo') }
     assert_raises(Liquid::SyntaxError) { variable_parse(' | nothing') }
+    assert_raises(Liquid::SyntaxError) { variable_parse('ending-dash-') }
 
     ['a .b', 'a. b', 'a . b'].each do |var|
       assert_raises(Liquid::SyntaxError) { variable_parse(var) }


### PR DESCRIPTION
@pushrax & @trishume for review

This just ports https://github.com/Shopify/liquid/pull/636 to liquid-c