### PR TITLE
Fix "comparison of integers of different signs"

### DIFF
--- a/ext/liquid_c/tokenizer.c
+++ b/ext/liquid_c/tokenizer.c
@@ -81,7 +81,7 @@ void tokenizer_next(tokenizer_t *tokenizer, token_t *token)
           cursor++;
           token->rstrip = 1;
         }
-        if (cursor - tokenizer->cursor > 2 + token->rstrip) {
+        if (cursor - tokenizer->cursor > (intptr_t)(2 + token->rstrip)) {
             token->type = TOKEN_RAW;
             cursor -= 2 + token->rstrip;
             token->lstrip = tokenizer->lstrip_flag;

--- a/ext/liquid_c/tokenizer.c
+++ b/ext/liquid_c/tokenizer.c
@@ -81,7 +81,7 @@ void tokenizer_next(tokenizer_t *tokenizer, token_t *token)
           cursor++;
           token->rstrip = 1;
         }
-        if (cursor - tokenizer->cursor > (intptr_t)(2 + token->rstrip)) {
+        if (cursor - tokenizer->cursor > (ptrdiff_t)(2 + token->rstrip)) {
             token->type = TOKEN_RAW;
             cursor -= 2 + token->rstrip;
             token->lstrip = tokenizer->lstrip_flag;


### PR DESCRIPTION
Got this error with latest Xcode installed on 10.11.5:

```
tokenizer.c:84:40: error: comparison of integers of different signs: 'int' and 'unsigned int' [-Werror,-Wsign-compare]
        if (cursor - tokenizer->cursor > 2 + token->rstrip) {
            ~~~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~
```