### PR TITLE
Update Travis for supported Rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 
 rvm:
-  - 2.0
-  - 2.1
   - 2.2
+  - 2.3
+  - 2.4.1
   - ruby-head
 
 sudo: false


### PR DESCRIPTION
Especially with Ruby 2.4 where the C API breaks because of the Fixnum/Bignum unification.