### PR TITLE
Refactor undefined default value for hash lookup

### DIFF
--- a/ext/liquid_c/parser.c
+++ b/ext/liquid_c/parser.c
@@ -120,9 +120,8 @@ static VALUE parse_variable(parser_t *p)
     }
 
     if (RARRAY_LEN(lookups) == 0) {
-        VALUE undefined = FIXNUM_P(-1);
-        VALUE literal = rb_hash_lookup2(vLiquidExpressionLiterals, name, undefined);
-        if (literal != undefined) return literal;
+        VALUE literal = rb_hash_lookup2(vLiquidExpressionLiterals, name, Qundef);
+        if (literal != Qundef) return literal;
     }
 
     VALUE args[4] = {Qfalse, name, lookups, INT2FIX(command_flags)};


### PR DESCRIPTION
## Problem

I noticed a weird line when looking for references to fixnum in the codebase

```ruby
VALUE undefined = FIXNUM_P(-1);
```

which seems very weird to me, since `FIXNUM_P` is meant to be used in a predicates (e.g. `if (FIXNUM_P(obj)) {`) and not a ruby `VALUE`.  I think maybe the code intended to do `INT2FIX(-1)` instead.  Instead, I think it is unintentionally relying on implementation details to continue working.

`FIXNUM_P(-1)` happens to be equivalent to `INT2FIX(0)` in the current implementation of MRI ruby, which only works since it isn't a value in the expresssion hash that this is used as a default value for.

## Solution

Use `Qundef` instead, since it is intended to be used as a value that can't be specified from ruby code.