### PR TITLE
Guard against $warnflags not being set by mkmf.

### DIFF
--- a/ext/liquid_c/extconf.rb
+++ b/ext/liquid_c/extconf.rb
@@ -4,5 +4,5 @@ compiler = RbConfig::MAKEFILE_CONFIG['CC']
 if ENV['DEBUG'] == 'true' && compiler =~ /gcc|g\+\+/
   $CFLAGS << ' -fbounds-check'
 end
-$warnflags.gsub!(/-Wdeclaration-after-statement/, "")
+$warnflags.gsub!(/-Wdeclaration-after-statement/, "") if $warnflags
 create_makefile("liquid_c")


### PR DESCRIPTION
$warnflags is conditionally set in mkmf and may end up being nil.