### PR TITLE
Fix Hash lookup with default value in parser.c

### DIFF
--- a/ext/liquid_c/parser.c
+++ b/ext/liquid_c/parser.c
@@ -120,9 +120,8 @@ static VALUE parse_variable(parser_t *p)
     }
 
     if (RARRAY_LEN(lookups) == 0) {
-        VALUE undefined = FIXNUM_P(-1);
-        VALUE literal = rb_hash_lookup2(vLiquidExpressionLiterals, name, undefined);
-        if (literal != undefined) return literal;
+        VALUE literal = rb_hash_lookup2(vLiquidExpressionLiterals, name, Qundef);
+        if (literal != Qundef) return literal;
     }
 
     VALUE args[4] = {Qfalse, name, lookups, INT2FIX(command_flags)};
@@ -193,4 +192,3 @@ void init_liquid_parser(void)
 
     vLiquidExpressionLiterals = rb_const_get(cLiquidExpression, rb_intern("LITERALS"));
 }
-


### PR DESCRIPTION
Hello,
We noticed this issue when trying this C extension on TruffleRuby.
The `FIXNUM_P(-1)` part seems rather odd as `FIXNUM_P()` should take a `VALUE` (an address).
`-1` happens to be the address of Fixnum `-1` on MRI, so `FIXNUM_P(-1)` returns `(VALUE) 1` which is Ruby Fixnum `0` and accidentaly works because there is no Fixnum `0` in the values of https://github.com/Shopify/liquid/blob/64fca66ef5dfd7cf1acef0a7b8cdd825756eb681/lib/liquid/expression.rb#L16-L22.

* The default value should be Qundef, not an arbitrary ((VALUE) 1).
* Qundef is not available in Ruby so it can safely be differentiated
  from Ruby-level values.