### PR TITLE
Fix right trim followed by a non-trimmed tag.

### DIFF
--- a/ext/liquid_c/tokenizer.c
+++ b/ext/liquid_c/tokenizer.c
@@ -88,6 +88,7 @@ void tokenizer_next(tokenizer_t *tokenizer, token_t *token)
             tokenizer->lstrip_flag = 0;
             goto found;
         }
+        tokenizer->lstrip_flag = 0;
         token->type = TOKEN_INVALID;
         token->lstrip = token->rstrip;
         token->rstrip = 0;


### PR DESCRIPTION
Fix for https://github.com/Shopify/liquid/issues/971

## Problem

We store lstrip_flag on the tokenizer so that we can trim the spaces following a tag ending with a whitespace control character (e.g. `-%}` or `-}}`), but if that tag is followed immediately by another tag, then it wasn't clearing that flag.  So in the liquid template `{{ "a" -}}{{ "b" }} c` the first tag's control character is applied to the text after the second tag.

## Solution

Clear `tokenizer->lstrip_flag` once we know the current token isn't raw text.

I will add a regression test upstream so it is used for both repos.