### PR TITLE
CI: test against supported Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 
 rvm:
-  - 2.2
   - 2.3
-  - 2.4.1
+  - 2.4
+  - 2.5
   - ruby-head
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 
 rvm:
-  - 2.3
+  - 2.2
   - 2.5
   - ruby-head
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 
 rvm:
   - 2.3
-  - 2.4
   - 2.5
   - ruby-head
 


### PR DESCRIPTION
 - Ruby 2.2 is EOL since march 2018
 - current stable version is 2.5
 - ruby-head is now a 2.6@dev