### PR TITLE
Skip allocating empty raw tokens

### DIFF
--- a/ext/liquid_c/block.c
+++ b/ext/liquid_c/block.c
@@ -65,11 +65,16 @@ static VALUE rb_block_parse(VALUE self, VALUE tokens, VALUE options)
             {
                 const char *start = token.str, *end = token.str + token.length, *token_start = start, *token_end = end;
 
-                if(token.lstrip)
+                if (token.lstrip)
                     token_start = read_while(start, end, rb_isspace);
-                if(token.rstrip)
+
+                if (token.rstrip)
                     token_end = read_while_end(token_start, end, rb_isspace);
-                    
+
+                // Skip token entirely if there is no data to be rendered.
+                if (token_start == token_end)
+                    break;
+
                 VALUE str = rb_enc_str_new(token_start, token_end - token_start, utf8_encoding);
                 rb_ary_push(nodelist, str);
 

--- a/liquid-c.gemspec
+++ b/liquid-c.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'liquid', '>= 3.0.0'
 
-  spec.add_development_dependency "bundler", "~> 1.5"
+  spec.add_development_dependency 'bundler', ">= 1.5" # has bugfix for segfaulting deploys
   spec.add_development_dependency "rake"
   spec.add_development_dependency 'rake-compiler'
   spec.add_development_dependency 'minitest'

--- a/test/liquid_test.rb
+++ b/test/liquid_test.rb
@@ -1,4 +1,4 @@
-liquid_lib_dir = $LOAD_PATH.detect{ |p| File.exists?(File.join(p, 'liquid.rb')) }
+liquid_lib_dir = $LOAD_PATH.detect{ |p| File.exist?(File.join(p, 'liquid.rb')) }
 liquid_test_dir = File.join(File.dirname(liquid_lib_dir), 'test')
 $LOAD_PATH << liquid_test_dir
 

--- a/test/unit/block_test.rb
+++ b/test/unit/block_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class BlockTest < MiniTest::Test
+  def test_no_allocation_of_trimmed_strings
+    template = Liquid::Template.parse("{{ -}}     {{- }}")
+    assert_equal 2, template.root.nodelist.size
+
+    template = Liquid::Template.parse("{{ -}} foo {{- }}")
+    assert_equal 3, template.root.nodelist.size
+  end
+end


### PR DESCRIPTION
Tiny change to reduce object allocation. Avoids allocating empty strings between tags with whitespace control `-}}   {{-`.

The ruby-head build is broken in general, tests do pass on 2.x.