### PR TITLE
Optimize VariableLookup#evaluate, Context#find_variable, Context#evaluate

### DIFF
--- a/ext/liquid_c/context.c
+++ b/ext/liquid_c/context.c
@@ -3,7 +3,7 @@
 #include "variable_lookup.h"
 
 static VALUE cLiquidVariableLookup, cLiquidUndefinedVariable;
-ID id_call, id_to_liquid, id_set_context;
+ID id_aset, id_call, id_to_liquid, id_set_context;
 static ID id_evaluate, id_has_key, id_aref;
 static ID id_ivar_scopes, id_ivar_environments, id_ivar_strict_variables;
 
@@ -43,11 +43,9 @@ VALUE context_find_variable(VALUE self, VALUE key, VALUE raise_on_not_found)
 
     VALUE scopes = rb_ivar_get(self, id_ivar_scopes);
     Check_Type(scopes, T_ARRAY);
-    const VALUE *scopes_ptr = RARRAY_CONST_PTR(scopes);
-    long scopes_len = RARRAY_LEN(scopes);
 
-    for (long i = 0; i < scopes_len; i++) {
-        VALUE this_scope = scopes_ptr[i];
+    for (long i = 0; i < RARRAY_LEN(scopes); i++) {
+        VALUE this_scope = RARRAY_AREF(scopes, i);
         if (RB_LIKELY(TYPE(this_scope) == T_HASH)) {
             // Does not invoke any default value proc, this is equivalent in
             // cost and semantics to #key? but loads the value as well
@@ -66,12 +64,10 @@ VALUE context_find_variable(VALUE self, VALUE key, VALUE raise_on_not_found)
 
     VALUE environments = rb_ivar_get(self, id_ivar_environments);
     Check_Type(environments, T_ARRAY);
-    const VALUE *environments_ptr = RARRAY_CONST_PTR(environments);
-    long environments_len = RARRAY_LEN(environments);
     VALUE strict_variables = rb_ivar_get(self, id_ivar_strict_variables);
 
-    for (long i = 0; i < environments_len; i++) {
-        VALUE this_environ = environments_ptr[i];
+    for (long i = 0; i < RARRAY_LEN(environments); i++) {
+        VALUE this_environ = RARRAY_AREF(environments, i);
         if (RB_LIKELY(TYPE(this_environ) == T_HASH)) {
             // Does not invoke any default value proc, this is equivalent in
             // cost and semantics to #key? but loads the value as well
@@ -115,6 +111,7 @@ void init_liquid_context()
     id_evaluate = rb_intern("evaluate");
     id_call = rb_intern("call");
     id_has_key = rb_intern("key?");
+    id_aset = rb_intern("[]=");
     id_aref = rb_intern("[]");
     id_to_liquid = rb_intern("to_liquid");
     id_set_context = rb_intern("context=");

--- a/ext/liquid_c/context.c
+++ b/ext/liquid_c/context.c
@@ -9,7 +9,7 @@ static ID id_ivar_scopes, id_ivar_environments, id_ivar_strict_variables;
 
 VALUE context_evaluate(VALUE self, VALUE expression)
 {
-    // Scalar type stored directly in the VALUE
+    // Scalar type stored directly in the VALUE, this is a nearly free check, saving a #respond_to?
     if (RB_SPECIAL_CONST_P(expression))
         return expression;
 
@@ -19,7 +19,8 @@ VALUE context_evaluate(VALUE self, VALUE expression)
     if (klass == rb_cString || klass == rb_cArray || klass == rb_cHash)
         return expression;
 
-    // Liquid::VariableLookup is by far the most common type after String
+    // Liquid::VariableLookup is by far the most common type after String, call
+    // the C implementation directly to avoid a Ruby dispatch.
     if (klass == cLiquidVariableLookup)
         return variable_lookup_evaluate(expression, self);
 

--- a/ext/liquid_c/context.c
+++ b/ext/liquid_c/context.c
@@ -1,0 +1,32 @@
+#include "liquid.h"
+
+static VALUE cLiquidVariableLookup;
+static ID idEvaluate;
+
+static VALUE context_evaluate(VALUE self, VALUE expression)
+{
+    // Scalar type stored directly in the VALUE
+    if (RB_SPECIAL_CONST_P(expression))
+        return expression;
+
+    VALUE klass = RBASIC(expression)->klass;
+
+    // Basic types that do not respond to #evaluate
+    if (klass == rb_cString || klass == rb_cArray || klass == rb_cHash)
+        return expression;
+
+    // Liquid::VariableLookup is by far the most common type after String
+    if (klass == cLiquidVariableLookup || rb_respond_to(expression, idEvaluate))
+        return rb_funcall(expression, idEvaluate, 1, self);
+
+    return expression;
+}
+
+void init_liquid_context()
+{
+    idEvaluate = rb_intern("evaluate");
+    cLiquidVariableLookup = rb_const_get(mLiquid, rb_intern("VariableLookup"));
+
+    VALUE cLiquidContext = rb_const_get(mLiquid, rb_intern("Context"));
+    rb_define_method(cLiquidContext, "c_evaluate", context_evaluate, 1);
+}

--- a/ext/liquid_c/context.c
+++ b/ext/liquid_c/context.c
@@ -1,9 +1,13 @@
 #include "liquid.h"
+#include "context.h"
+#include "variable_lookup.h"
 
-static VALUE cLiquidVariableLookup;
-static ID idEvaluate;
+static VALUE cLiquidVariableLookup, cLiquidUndefinedVariable;
+ID id_call, id_to_liquid, id_set_context;
+static ID id_evaluate, id_has_key, id_aref;
+static ID id_ivar_scopes, id_ivar_environments, id_ivar_strict_variables;
 
-static VALUE context_evaluate(VALUE self, VALUE expression)
+VALUE context_evaluate(VALUE self, VALUE expression)
 {
     // Scalar type stored directly in the VALUE
     if (RB_SPECIAL_CONST_P(expression))
@@ -16,17 +20,94 @@ static VALUE context_evaluate(VALUE self, VALUE expression)
         return expression;
 
     // Liquid::VariableLookup is by far the most common type after String
-    if (klass == cLiquidVariableLookup || rb_respond_to(expression, idEvaluate))
-        return rb_funcall(expression, idEvaluate, 1, self);
+    if (klass == cLiquidVariableLookup)
+        return variable_lookup_evaluate(expression, self);
+
+    if (rb_respond_to(expression, id_evaluate))
+        return rb_funcall(expression, id_evaluate, 1, self);
 
     return expression;
 }
 
+void context_maybe_raise_undefined_variable(VALUE self, VALUE key)
+{
+    if (rb_ivar_get(self, id_ivar_strict_variables)) {
+        Check_Type(key, T_STRING);
+        rb_enc_raise(utf8_encoding, cLiquidUndefinedVariable, "undefined variable %s", RSTRING_PTR(key));
+    }
+}
+
+VALUE context_find_variable(VALUE self, VALUE key, VALUE raise_on_not_found)
+{
+    VALUE scope = Qnil, variable = Qnil;
+
+    VALUE scopes = rb_ivar_get(self, id_ivar_scopes);
+    Check_Type(scopes, T_ARRAY);
+    const VALUE *scopes_ptr = RARRAY_CONST_PTR(scopes);
+    long scopes_len = RARRAY_LEN(scopes);
+
+    for (long i = 0; i < scopes_len; i++) {
+        VALUE this_scope = scopes_ptr[i];
+        if (TYPE(this_scope) == T_HASH) {
+            variable = rb_hash_lookup2(this_scope, key, Qundef);
+            if (variable != Qundef) {
+                scope = this_scope;
+                goto variable_found;
+            }
+        } else if (RTEST(rb_funcall(this_scope, id_has_key, 1, key))) {
+            variable = rb_funcall(this_scope, id_aref, 1, key);
+            goto variable_found;
+        }
+    }
+
+    VALUE environments = rb_ivar_get(self, id_ivar_environments);
+    Check_Type(environments, T_ARRAY);
+    const VALUE *environments_ptr = RARRAY_CONST_PTR(environments);
+    long environments_len = RARRAY_LEN(environments);
+
+    for (long i = 0; i < environments_len; i++) {
+        VALUE this_environ = environments_ptr[i];
+        if (TYPE(this_environ) == T_HASH) {
+            variable = rb_hash_lookup2(this_environ, key, Qundef);
+            if (variable != Qundef) {
+                scope = this_environ;
+                goto variable_found;
+            }
+        } else if (RTEST(rb_funcall(this_environ, id_has_key, 1, key))) {
+            variable = rb_funcall(this_environ, id_aref, 1, key);
+            goto variable_found;
+        }
+    }
+
+    if (RTEST(raise_on_not_found)) {
+        context_maybe_raise_undefined_variable(self, key);
+    }
+    variable = Qnil;
+
+variable_found:
+    variable = materialize_proc(self, scope, key, variable);
+    variable = value_to_liquid_and_set_context(variable, self);
+
+    return variable;
+}
+
 void init_liquid_context()
 {
-    idEvaluate = rb_intern("evaluate");
+    id_evaluate = rb_intern("evaluate");
+    id_call = rb_intern("call");
+    id_has_key = rb_intern("key?");
+    id_aref = rb_intern("[]");
+    id_to_liquid = rb_intern("to_liquid");
+    id_set_context = rb_intern("context=");
+
+    id_ivar_scopes = rb_intern("@scopes");
+    id_ivar_environments = rb_intern("@environments");
+    id_ivar_strict_variables = rb_intern("@strict_variables");
+
     cLiquidVariableLookup = rb_const_get(mLiquid, rb_intern("VariableLookup"));
+    cLiquidUndefinedVariable = rb_const_get(mLiquid, rb_intern("UndefinedVariable"));
 
     VALUE cLiquidContext = rb_const_get(mLiquid, rb_intern("Context"));
     rb_define_method(cLiquidContext, "c_evaluate", context_evaluate, 1);
+    rb_define_method(cLiquidContext, "c_find_variable", context_find_variable, 2);
 }

--- a/ext/liquid_c/context.h
+++ b/ext/liquid_c/context.h
@@ -2,6 +2,44 @@
 #define LIQUID_CONTEXT_H
 
 void init_liquid_context();
+VALUE context_evaluate(VALUE self, VALUE expression);
+VALUE context_find_variable(VALUE self, VALUE key, VALUE raise_on_not_found);
+void context_maybe_raise_undefined_variable(VALUE self, VALUE key);
+
+extern ID id_call, id_to_liquid, id_set_context;
+
+inline static VALUE value_to_liquid_and_set_context(VALUE value, VALUE context_to_set)
+{
+    if (RB_SPECIAL_CONST_P(value))
+        return value;
+
+    VALUE klass = RBASIC(value)->klass;
+    if (klass == rb_cString || klass == rb_cArray || klass == rb_cHash)
+        return value;
+
+    value = rb_funcall(value, id_to_liquid, 0);
+
+    if (rb_respond_to(value, id_set_context))
+        rb_funcall(value, id_set_context, 1, context_to_set);
+
+    return value;
+}
+
+
+inline static VALUE materialize_proc(VALUE context, VALUE scope, VALUE key, VALUE value)
+{
+    if (scope != Qnil && !RB_SPECIAL_CONST_P(value) && TYPE(scope) == T_HASH) {
+        if (rb_obj_is_kind_of(value, rb_cProc)) {
+            if (rb_proc_arity(value) == 1) {
+                value = rb_funcall(value, id_call, 1, context);
+            } else {
+                value = rb_funcall(value, id_call, 0);
+            }
+            rb_hash_aset(scope, key, value);
+        }
+    }
+    return value;
+}
 
 #endif
 

--- a/ext/liquid_c/context.h
+++ b/ext/liquid_c/context.h
@@ -15,10 +15,14 @@ extern ID id_aset, id_call, id_to_liquid, id_set_context;
 
 inline static VALUE value_to_liquid_and_set_context(VALUE value, VALUE context_to_set)
 {
+    // Scalar type stored directly in the VALUE, these all have a #to_liquid
+    // that returns self, and should have no #context= method
     if (RB_SPECIAL_CONST_P(value))
         return value;
 
     VALUE klass = RBASIC(value)->klass;
+
+    // More basic types having #to_liquid of self and no #context=
     if (klass == rb_cString || klass == rb_cArray || klass == rb_cHash)
         return value;
 

--- a/ext/liquid_c/context.h
+++ b/ext/liquid_c/context.h
@@ -8,6 +8,11 @@ void context_maybe_raise_undefined_variable(VALUE self, VALUE key);
 
 extern ID id_call, id_to_liquid, id_set_context;
 
+#ifndef RB_SPECIAL_CONST_P
+// RB_SPECIAL_CONST_P added in Ruby 2.3
+#define RB_SPECIAL_CONST_P SPECIAL_CONST_P
+#endif
+
 inline static VALUE value_to_liquid_and_set_context(VALUE value, VALUE context_to_set)
 {
     if (RB_SPECIAL_CONST_P(value))

--- a/ext/liquid_c/context.h
+++ b/ext/liquid_c/context.h
@@ -1,0 +1,7 @@
+#if !defined(LIQUID_CONTEXT_H)
+#define LIQUID_CONTEXT_H
+
+void init_liquid_context();
+
+#endif
+

--- a/ext/liquid_c/extconf.rb
+++ b/ext/liquid_c/extconf.rb
@@ -1,5 +1,5 @@
 require 'mkmf'
-$CFLAGS << ' -Wall -Werror -Wextra -Wno-unused-parameter -Wno-missing-field-initializers'
+$CFLAGS << ' -std=c99 -Wall -Werror -Wextra -Wno-unused-parameter -Wno-missing-field-initializers'
 compiler = RbConfig::MAKEFILE_CONFIG['CC']
 if ENV['DEBUG'] == 'true' && compiler =~ /gcc|g\+\+/
   $CFLAGS << ' -fbounds-check'

--- a/ext/liquid_c/liquid.c
+++ b/ext/liquid_c/liquid.c
@@ -4,6 +4,7 @@
 #include "lexer.h"
 #include "parser.h"
 #include "block.h"
+#include "context.h"
 
 VALUE mLiquid, mLiquidC, cLiquidSyntaxError, cLiquidVariable, cLiquidTemplate;
 rb_encoding *utf8_encoding;
@@ -21,5 +22,6 @@ void Init_liquid_c(void)
     init_liquid_parser();
     init_liquid_variable();
     init_liquid_block();
+    init_liquid_context();
 }
 

--- a/ext/liquid_c/liquid.c
+++ b/ext/liquid_c/liquid.c
@@ -5,6 +5,7 @@
 #include "parser.h"
 #include "block.h"
 #include "context.h"
+#include "variable_lookup.h"
 
 VALUE mLiquid, mLiquidC, cLiquidSyntaxError, cLiquidVariable, cLiquidTemplate;
 rb_encoding *utf8_encoding;
@@ -23,5 +24,6 @@ void Init_liquid_c(void)
     init_liquid_variable();
     init_liquid_block();
     init_liquid_context();
+    init_liquid_variable_lookup();
 }
 

--- a/ext/liquid_c/liquid.h
+++ b/ext/liquid_c/liquid.h
@@ -8,5 +8,10 @@
 extern VALUE mLiquid, mLiquidC, cLiquidSyntaxError, cLiquidVariable, cLiquidTemplate;
 extern rb_encoding *utf8_encoding;
 
+#ifndef RB_LIKELY
+// RB_LIKELY added in Ruby 2.4
+#define RB_LIKELY(x) (__builtin_expect(!!(x), 1))
+#endif
+
 #endif
 

--- a/ext/liquid_c/variable_lookup.c
+++ b/ext/liquid_c/variable_lookup.c
@@ -14,11 +14,9 @@ VALUE variable_lookup_evaluate(VALUE self, VALUE context)
 
     VALUE lookups = rb_ivar_get(self, id_ivar_lookups);
     Check_Type(lookups, T_ARRAY);
-    const VALUE *lookups_ptr = RARRAY_CONST_PTR(lookups);
-    long lookups_len = RARRAY_LEN(lookups);
 
-    for (long i = 0; i < lookups_len; i++) {
-        VALUE key = context_evaluate(context, lookups_ptr[i]);
+    for (long i = 0; i < RARRAY_LEN(lookups); i++) {
+        VALUE key = context_evaluate(context, RARRAY_AREF(lookups, i));
         VALUE next_object;
 
         if (rb_respond_to(object, id_aref) && (
@@ -26,7 +24,7 @@ VALUE variable_lookup_evaluate(VALUE self, VALUE context)
             (rb_obj_is_kind_of(key, rb_cInteger) && rb_respond_to(object, id_fetch))
         )) {
             next_object = rb_funcall(object, id_aref, 1, key);
-            materialize_proc(context, object, key, next_object);
+            next_object = materialize_proc(context, object, key, next_object);
             object = value_to_liquid_and_set_context(next_object, context);
             continue;
         }

--- a/ext/liquid_c/variable_lookup.c
+++ b/ext/liquid_c/variable_lookup.c
@@ -1,0 +1,66 @@
+#include "liquid.h"
+#include "context.h"
+
+static ID id_has_key, id_aref, id_fetch;
+static ID id_ivar_lookups, id_ivar_name, id_ivar_command_flags;
+
+VALUE variable_lookup_evaluate(VALUE self, VALUE context)
+{
+    VALUE command_flags = 0;
+    VALUE name = rb_ivar_get(self, id_ivar_name);
+    name = context_evaluate(context, name);
+
+    VALUE object = context_find_variable(context, name, Qtrue);
+
+    VALUE lookups = rb_ivar_get(self, id_ivar_lookups);
+    Check_Type(lookups, T_ARRAY);
+    const VALUE *lookups_ptr = RARRAY_CONST_PTR(lookups);
+    long lookups_len = RARRAY_LEN(lookups);
+
+    for (long i = 0; i < lookups_len; i++) {
+        VALUE key = context_evaluate(context, lookups_ptr[i]);
+        VALUE next_object;
+
+        if (rb_respond_to(object, id_aref) && (
+            (rb_respond_to(object, id_has_key) && rb_funcall(object, id_has_key, 1, key)) ||
+            (rb_obj_is_kind_of(key, rb_cInteger) && rb_respond_to(object, id_fetch))
+        )) {
+            next_object = rb_funcall(object, id_aref, 1, key);
+            materialize_proc(context, object, key, next_object);
+            object = value_to_liquid_and_set_context(next_object, context);
+            continue;
+        }
+
+        if (!command_flags) {
+            command_flags = rb_ivar_get(self, id_ivar_command_flags);
+        }
+        if (NUM2LONG(command_flags) & (1 << i)) {
+            Check_Type(key, T_STRING);
+            ID intern_key = rb_intern(RSTRING_PTR(key));
+            if (rb_respond_to(object, intern_key)) {
+                next_object = rb_funcall(object, rb_intern(RSTRING_PTR(key)), 0);
+                object = value_to_liquid_and_set_context(next_object, context);
+                continue;
+            }
+        }
+
+        context_maybe_raise_undefined_variable(context, key);
+        return Qnil;
+    }
+
+    return object;
+}
+
+void init_liquid_variable_lookup()
+{
+    id_has_key = rb_intern("key?");
+    id_aref = rb_intern("[]");
+    id_fetch = rb_intern("fetch");
+
+    id_ivar_lookups = rb_intern("@lookups");
+    id_ivar_name = rb_intern("@name");
+    id_ivar_command_flags = rb_intern("@command_flags");
+
+    VALUE cLiquidVariableLookup = rb_const_get(mLiquid, rb_intern("VariableLookup"));
+    rb_define_method(cLiquidVariableLookup, "c_evaluate", variable_lookup_evaluate, 1);
+}

--- a/ext/liquid_c/variable_lookup.c
+++ b/ext/liquid_c/variable_lookup.c
@@ -6,7 +6,7 @@ static ID id_ivar_lookups, id_ivar_name, id_ivar_command_flags;
 
 VALUE variable_lookup_evaluate(VALUE self, VALUE context)
 {
-    VALUE command_flags = 0;
+    long command_flags = -1;
     VALUE name = rb_ivar_get(self, id_ivar_name);
     name = context_evaluate(context, name);
 
@@ -29,10 +29,10 @@ VALUE variable_lookup_evaluate(VALUE self, VALUE context)
             continue;
         }
 
-        if (!command_flags) {
-            command_flags = rb_ivar_get(self, id_ivar_command_flags);
+        if (command_flags == -1) {
+            command_flags = NUM2LONG(rb_ivar_get(self, id_ivar_command_flags));
         }
-        if (NUM2LONG(command_flags) & (1 << i)) {
+        if (command_flags & (1 << i)) {
             Check_Type(key, T_STRING);
             ID intern_key = rb_intern(RSTRING_PTR(key));
             if (rb_respond_to(object, intern_key)) {

--- a/ext/liquid_c/variable_lookup.h
+++ b/ext/liquid_c/variable_lookup.h
@@ -1,0 +1,8 @@
+#if !defined(LIQUID_VARIABLE_LOOKUP_H)
+#define LIQUID_VARIABLE_LOOKUP_H
+
+void init_liquid_variable_lookup();
+VALUE variable_lookup_evaluate(VALUE self, VALUE expression);
+
+#endif
+

--- a/lib/liquid/c.rb
+++ b/lib/liquid/c.rb
@@ -95,7 +95,9 @@ Liquid::Context.class_eval do
   end
 end
 
-Liquid::VariableLookup.alias_method :ruby_evaluate, :evaluate
+Liquid::VariableLookup.class_eval do
+  alias_method :ruby_evaluate, :evaluate
+end
 
 module Liquid
   module C
@@ -105,13 +107,13 @@ module Liquid
       def enabled=(value)
         @enabled = value
         if value
-          Liquid::Context.alias_method :evaluate, :c_evaluate
-          Liquid::Context.alias_method :find_variable, :c_find_variable_kwarg
-          Liquid::VariableLookup.alias_method :evaluate, :c_evaluate
+          Liquid::Context.send(:alias_method, :evaluate, :c_evaluate)
+          Liquid::Context.send(:alias_method, :find_variable, :c_find_variable_kwarg)
+          Liquid::VariableLookup.send(:alias_method, :evaluate, :c_evaluate)
         else
-          Liquid::Context.alias_method :evaluate, :ruby_evaluate
-          Liquid::Context.alias_method :find_variable, :ruby_find_variable
-          Liquid::VariableLookup.alias_method :evaluate, :ruby_evaluate
+          Liquid::Context.send(:alias_method, :evaluate, :ruby_evaluate)
+          Liquid::Context.send(:alias_method, :find_variable, :ruby_find_variable)
+          Liquid::VariableLookup.send(:alias_method, :evaluate, :ruby_evaluate)
         end
       end
     end

--- a/lib/liquid/c.rb
+++ b/lib/liquid/c.rb
@@ -84,7 +84,18 @@ Liquid::Expression.class_eval do
   end
 end
 
-Liquid::Context.alias_method :ruby_evaluate, :evaluate
+Liquid::Context.class_eval do
+  alias_method :ruby_evaluate, :evaluate
+  alias_method :ruby_find_variable, :find_variable
+
+  # This isn't entered often by Ruby (most calls stay in C via VariableLookup#evaluate)
+  # so the wrapper method isn't costly.
+  def c_find_variable_kwarg(key, raise_on_not_found: true)
+    c_find_variable(key, raise_on_not_found)
+  end
+end
+
+Liquid::VariableLookup.alias_method :ruby_evaluate, :evaluate
 
 module Liquid
   module C
@@ -95,8 +106,12 @@ module Liquid
         @enabled = value
         if value
           Liquid::Context.alias_method :evaluate, :c_evaluate
+          Liquid::Context.alias_method :find_variable, :c_find_variable_kwarg
+          Liquid::VariableLookup.alias_method :evaluate, :c_evaluate
         else
           Liquid::Context.alias_method :evaluate, :ruby_evaluate
+          Liquid::Context.alias_method :find_variable, :ruby_find_variable
+          Liquid::VariableLookup.alias_method :evaluate, :ruby_evaluate
         end
       end
     end

--- a/lib/liquid/c.rb
+++ b/lib/liquid/c.rb
@@ -2,16 +2,6 @@ require 'liquid/c/version'
 require 'liquid'
 require 'liquid_c'
 
-module Liquid
-  module C
-    @enabled = true
-
-    class << self
-      attr_accessor :enabled
-    end
-  end
-end
-
 Liquid::Tokenizer.class_eval do
   def self.new(source, line_numbers = false)
     if Liquid::C.enabled
@@ -91,5 +81,26 @@ Liquid::Expression.class_eval do
       end
       ruby_parse(markup)
     end
+  end
+end
+
+Liquid::Context.alias_method :ruby_evaluate, :evaluate
+
+module Liquid
+  module C
+    class << self
+      attr_reader :enabled
+
+      def enabled=(value)
+        @enabled = value
+        if value
+          Liquid::Context.alias_method :evaluate, :c_evaluate
+        else
+          Liquid::Context.alias_method :evaluate, :ruby_evaluate
+        end
+      end
+    end
+
+    self.enabled = true
   end
 end

--- a/test/liquid_test.rb
+++ b/test/liquid_test.rb
@@ -5,7 +5,7 @@ $LOAD_PATH << liquid_test_dir
 require 'test_helper'
 require 'liquid/c'
 
-test_files = FileList[File.join(liquid_test_dir, 'integration/**/*_test.rb')]
+test_files = FileList[File.join(liquid_test_dir, '**/*_test.rb')]
 test_files.each do |test_file|
   require test_file
 end

--- a/test/unit/context_test.rb
+++ b/test/unit/context_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+require 'bigdecimal'
+
+class ContextTest < Minitest::Test
+  def test_evaluate_works_with_normal_values
+    context = Liquid::Context.new
+
+    ["abc", 123, false, 1.21, BigDecimal(42)].each do |value|
+      assert_equal value, context.evaluate(value)
+    end
+
+    assert_nil context.evaluate(nil)
+  end
+
+  def test_evaluate_works_with_classes_that_have_an_evaluate_method
+    class_with_evaluate = Class.new do
+      def evaluate(context)
+        42
+      end
+    end
+
+    assert_equal 42, Liquid::Context.new.evaluate(class_with_evaluate.new)
+  end
+
+  def test_evaluate_works_with_variable_lookup
+    assert_equal 42, Liquid::Context.new({"var" => 42}).evaluate(Liquid::VariableLookup.new("var"))
+  end
+end

--- a/test/unit/context_test.rb
+++ b/test/unit/context_test.rb
@@ -25,4 +25,30 @@ class ContextTest < Minitest::Test
   def test_evaluate_works_with_variable_lookup
     assert_equal 42, Liquid::Context.new({"var" => 42}).evaluate(Liquid::VariableLookup.new("var"))
   end
+
+  def test_evaluating_a_variable_entirely_within_c
+    context = Liquid::Context.new({"var" => 42})
+    lookup = Liquid::VariableLookup.new("var")
+
+    called_ruby_method_count = 0
+    called_c_method_count = 0
+
+    begin
+      call_trace = TracePoint.trace(:call) do |t|
+        called_ruby_method_count += 1
+      end
+
+      c_call_trace = TracePoint.trace(:c_call) do |t|
+        called_c_method_count += 1 if t.method_id != :disable
+      end
+
+      context.evaluate(lookup)
+    ensure
+      call_trace&.disable
+      c_call_trace&.disable
+    end
+
+    assert_equal 0, called_ruby_method_count
+    assert_equal 1, called_c_method_count # context.evaluate call
+  end
 end

--- a/test/unit/context_test.rb
+++ b/test/unit/context_test.rb
@@ -44,8 +44,8 @@ class ContextTest < Minitest::Test
 
       context.evaluate(lookup)
     ensure
-      call_trace&.disable
-      c_call_trace&.disable
+      call_trace.disable if call_trace
+      c_call_trace.disable if c_call_trace
     end
 
     assert_equal 0, called_ruby_method_count


### PR DESCRIPTION
This optimizes a hot path in rendering: the interaction of VariableLookup#evaluate, Context#find_variable, and Context#evaluate. With this change, we stay entirely within C for the whole blob of logic required to look up and evaluate variables. This produces the following change in render performance:

```
/opt/rubies/2.6.2/bin/ruby ./performance.rb bare benchmark strict

Running benchmark for 10 seconds (with 5 seconds warmup).

Warming up --------------------------------------
              parse:     2.000  i/100ms
             render:     7.000  i/100ms
     parse & render:     1.000  i/100ms
Calculating -------------------------------------
              parse:     26.251  (± 3.8%) i/s -    262.000  in  10.001189s
             render:     77.849  (± 5.1%) i/s -    777.000  in  10.002960s
     parse & render:     18.779  (± 5.3%) i/s -    188.000  in  10.034829s

/opt/rubies/2.6.2/bin/ruby ./performance.rb c benchmark strict

Running benchmark for 10 seconds (with 5 seconds warmup).

Warming up --------------------------------------
              parse:    10.000  i/100ms
             render:    10.000  i/100ms
     parse & render:     4.000  i/100ms
Calculating -------------------------------------
              parse:    104.356  (± 3.8%) i/s -      1.050k in  10.078616s
             render:    102.800  (± 4.9%) i/s -      1.030k in  10.046901s
     parse & render:     47.821  (± 4.2%) i/s -    480.000  in  10.058512s
```

This is the first set of render-related optimizations, so the `render` row can be compared directly. On a large Shopify merchant's theme, we see >20% reduction in Liquid rendering cost. 

@Shopify/liquid thoughts?