### PR TITLE
Let RangeLookup handle all ranges

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'liquid', github: 'Shopify/liquid', branch: 'master'
-
+gem 'liquid', github: 'Shopify/liquid', branch: 'range-optimization'
 
 group :test do
   gem 'spy', '0.4.1'

--- a/ext/liquid_c/parser.c
+++ b/ext/liquid_c/parser.c
@@ -2,7 +2,7 @@
 #include "parser.h"
 #include "lexer.h"
 
-static VALUE cLiquidRangeLookup, cLiquidVariableLookup, cRange, vLiquidExpressionLiterals;
+static VALUE cLiquidRangeLookup, cLiquidVariableLookup, vLiquidExpressionLiterals;
 static ID idToI, idEvaluate;
 
 void init_parser(parser_t *p, const char *str, const char *end)
@@ -78,10 +78,7 @@ static VALUE parse_range(parser_t *p)
     args[1] = parse_expression(p);
     parser_must_consume(p, TOKEN_CLOSE_ROUND);
 
-    if (rb_respond_to(args[0], idEvaluate) || rb_respond_to(args[1], idEvaluate))
-        return rb_class_new_instance(2, args, cLiquidRangeLookup);
-
-    return rb_class_new_instance(2, args, cRange);
+    return rb_class_new_instance(2, args, cLiquidRangeLookup);
 }
 
 static VALUE parse_variable(parser_t *p)
@@ -184,7 +181,6 @@ void init_liquid_parser(void)
     idEvaluate = rb_intern("evaluate");
 
     cLiquidRangeLookup = rb_const_get(mLiquid, rb_intern("RangeLookup"));
-    cRange = rb_const_get(rb_cObject, rb_intern("Range"));
     cLiquidVariableLookup = rb_const_get(mLiquid, rb_intern("VariableLookup"));
 
     VALUE cLiquidExpression = rb_const_get(mLiquid, rb_intern("Expression"));


### PR DESCRIPTION
@pushrax @samdoiron Possible solution for https://github.com/Shopify/liquid/pull/1109

I don't think we need to really even support basic ranges when we have a RangeLookup anyway. If everything goes through this they are much easier to modify and extend