### PR TITLE
Bump ruby to 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 
 rvm:
-  - 2.2
-  - 2.5
+  - 2.4
+  - 2.6
   - ruby-head
 
 sudo: false

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'liquid', github: 'Shopify/liquid', branch: 'master'
+gem 'liquid', github: 'Shopify/liquid', ref: '831355dfbd4f78c5365f2e3f919e57993209ad76'
 
 
 group :test do

--- a/lib/liquid/c.rb
+++ b/lib/liquid/c.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'liquid/c/version'
 require 'liquid'
 require 'liquid_c'

--- a/lib/liquid/c/version.rb
+++ b/lib/liquid/c/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Liquid
   module C
     VERSION = "4.0.0"


### PR DESCRIPTION
https://github.com/Shopify/liquid/pull/1131 changed the minimum supported ruby version to 2.4 for liquid, so we can change the minimum tested with here too.  We can also test against the latest released ruby version.

This isn't testing against the latest liquid version though, since https://github.com/Shopify/liquid-c/pull/43 is needed to resolve that conflict.  However, that PR was failing on ruby 2.2, so I figured this PR could help.