### PR TITLE
Honor pre-trim for tags

### DIFF
--- a/ext/liquid_c/stringutil.h
+++ b/ext/liquid_c/stringutil.h
@@ -10,7 +10,7 @@ inline static const char *read_while(const char *start, const char *end, int (fu
 inline static const char *read_while_reverse(const char *start, const char *end, int (func)(int))
 {
     end--;
-    while (start < end && func((unsigned char) *end)) end--;
+    while (start <= end && func((unsigned char) *end)) end--;
     end++;
     return end;
 }

--- a/test/unit/block_test.rb
+++ b/test/unit/block_test.rb
@@ -8,4 +8,12 @@ class BlockTest < MiniTest::Test
     template = Liquid::Template.parse("{{ -}} foo {{- }}")
     assert_equal 3, template.root.nodelist.size
   end
+
+  def test_pre_trim
+    template = Liquid::Template.parse("\n{%- raw %}{% endraw %}")
+    assert_equal "", template.render
+
+    template = Liquid::Template.parse("\n{%- if true %}{% endif %}")
+    assert_equal "", template.render
+  end
 end


### PR DESCRIPTION
Not the fastest way to do it -- I think doing it in the tokenizer is
better. Let me know if this is acceptable.