### PR TITLE
Fix tracepoint test on ruby master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 
 rvm:
   - 2.4
-  - 2.6
+  - 2.7
   - ruby-head
 
 sudo: false

--- a/test/unit/context_test.rb
+++ b/test/unit/context_test.rb
@@ -35,11 +35,15 @@ class ContextTest < Minitest::Test
 
     begin
       call_trace = TracePoint.trace(:call) do |t|
-        called_ruby_method_count += 1
+        unless t.self == TracePoint || t.self.is_a?(TracePoint)
+          called_ruby_method_count += 1
+        end
       end
 
       c_call_trace = TracePoint.trace(:c_call) do |t|
-        called_c_method_count += 1 if t.method_id != :disable
+        unless t.self == TracePoint || t.self.is_a?(TracePoint)
+          called_c_method_count += 1
+        end
       end
 
       context.evaluate(lookup)


### PR DESCRIPTION
As mentioned in https://github.com/Shopify/liquid-c/pull/52#issuecomment-567293796, CI started failing on ruby master.

The failing test is counting ruby calls using a tracepoint and started picking up a couple of calls to TracePoint.trace and TracePoint#disable.  We were already ignoring disable C calls, so I changed the code to ignore both ruby and C tracepoint calls, since they aren't relevant to the code under test.