### PR TITLE
Temporarily allow opt-in bug compatible whitespace trimming

### DIFF
--- a/ext/liquid_c/block.c
+++ b/ext/liquid_c/block.c
@@ -73,8 +73,13 @@ static VALUE internal_block_parse(VALUE self, VALUE tokens, VALUE parse_context,
                 if (token.lstrip)
                     token_start = read_while(start, end, rb_isspace);
 
-                if (token.rstrip)
-                    token_end = read_while_reverse(token_start, end, rb_isspace);
+                if (token.rstrip) {
+                    if (tokenizer->bug_compatible_whitespace_trimming) {
+                        token_end = read_while_reverse(token_start + 1, end, rb_isspace);
+                    } else {
+                        token_end = read_while_reverse(token_start, end, rb_isspace);
+                    }
+                }
 
                 // Skip token entirely if there is no data to be rendered.
                 if (token_start == token_end)

--- a/ext/liquid_c/tokenizer.c
+++ b/ext/liquid_c/tokenizer.c
@@ -262,6 +262,8 @@ static VALUE tokenizer_for_liquid_tag_method(VALUE self)
     return tokenizer->for_liquid_tag ? Qtrue : Qfalse;
 }
 
+
+// Temporary to test rollout of the fix for this bug
 static VALUE tokenizer_bug_compatible_whitespace_trimming(VALUE self) {
     tokenizer_t *tokenizer;
     Tokenizer_Get_Struct(self, tokenizer);

--- a/ext/liquid_c/tokenizer.c
+++ b/ext/liquid_c/tokenizer.c
@@ -36,6 +36,7 @@ static VALUE tokenizer_allocate(VALUE klass)
 
     obj = TypedData_Make_Struct(klass, tokenizer_t, &tokenizer_data_type, tokenizer);
     tokenizer->source = Qnil;
+    tokenizer->bug_compatible_whitespace_trimming = false;
     return obj;
 }
 
@@ -261,6 +262,14 @@ static VALUE tokenizer_for_liquid_tag_method(VALUE self)
     return tokenizer->for_liquid_tag ? Qtrue : Qfalse;
 }
 
+static VALUE tokenizer_bug_compatible_whitespace_trimming(VALUE self) {
+    tokenizer_t *tokenizer;
+    Tokenizer_Get_Struct(self, tokenizer);
+
+    tokenizer->bug_compatible_whitespace_trimming = true;
+    return Qnil;
+}
+
 void init_liquid_tokenizer()
 {
     cLiquidTokenizer = rb_define_class_under(mLiquidC, "Tokenizer", rb_cObject);
@@ -269,6 +278,7 @@ void init_liquid_tokenizer()
     rb_define_method(cLiquidTokenizer, "shift", tokenizer_shift_method, 0);
     rb_define_method(cLiquidTokenizer, "line_number", tokenizer_line_number_method, 0);
     rb_define_method(cLiquidTokenizer, "for_liquid_tag", tokenizer_for_liquid_tag_method, 0);
+    rb_define_method(cLiquidTokenizer, "bug_compatible_whitespace_trimming!", tokenizer_bug_compatible_whitespace_trimming, 0);
 
     // For testing the internal token representation.
     rb_define_private_method(cLiquidTokenizer, "shift_trimmed", tokenizer_shift_trimmed_method, 0);

--- a/ext/liquid_c/tokenizer.h
+++ b/ext/liquid_c/tokenizer.h
@@ -25,6 +25,7 @@ typedef struct tokenizer {
     unsigned int line_number;
     bool lstrip_flag;
     bool for_liquid_tag;
+    bool bug_compatible_whitespace_trimming;
 } tokenizer_t;
 
 extern VALUE cLiquidTokenizer;

--- a/ext/liquid_c/tokenizer.h
+++ b/ext/liquid_c/tokenizer.h
@@ -25,6 +25,8 @@ typedef struct tokenizer {
     unsigned int line_number;
     bool lstrip_flag;
     bool for_liquid_tag;
+
+    // Temporary to test rollout of the fix for this bug
     bool bug_compatible_whitespace_trimming;
 } tokenizer_t;
 

--- a/lib/liquid/c.rb
+++ b/lib/liquid/c.rb
@@ -27,6 +27,7 @@ Liquid::BlockBody.class_eval do
 end
 
 module Liquid::C
+  # Temporary to test rollout of the fix for this bug
   module DocumentPatch
     def parse(tokenizer, parse_context)
       if tokenizer.is_a?(Liquid::C::Tokenizer) && parse_context[:bug_compatible_whitespace_trimming]

--- a/lib/liquid/c.rb
+++ b/lib/liquid/c.rb
@@ -26,6 +26,18 @@ Liquid::BlockBody.class_eval do
   end
 end
 
+module Liquid::C
+  module DocumentPatch
+    def parse(tokenizer, parse_context)
+      if tokenizer.is_a?(Liquid::C::Tokenizer) && parse_context[:bug_compatible_whitespace_trimming]
+        tokenizer.bug_compatible_whitespace_trimming!
+      end
+      super
+    end
+  end
+  Liquid::Document.prepend(DocumentPatch)
+end
+
 Liquid::Variable.class_eval do
   alias_method :ruby_lax_parse, :lax_parse
   alias_method :ruby_strict_parse, :strict_parse

--- a/test/unit/block_test.rb
+++ b/test/unit/block_test.rb
@@ -16,4 +16,21 @@ class BlockTest < MiniTest::Test
     template = Liquid::Template.parse("\n{%- if true %}{% endif %}")
     assert_equal "", template.render
   end
+
+  def test_bug_compatible_pre_trim
+    template = Liquid::Template.parse("\n {%- raw %}{% endraw %}", bug_compatible_whitespace_trimming: true)
+    assert_equal "\n", template.render
+
+    template = Liquid::Template.parse("\n {%- if true %}{% endif %}", bug_compatible_whitespace_trimming: true)
+    assert_equal "\n", template.render
+
+    template = Liquid::Template.parse("{{ 'B' }} \n{%- if true %}C{% endif %}", bug_compatible_whitespace_trimming: true)
+    assert_equal "B C", template.render
+
+    template = Liquid::Template.parse("B\n {%- raw %}{% endraw %}", bug_compatible_whitespace_trimming: true)
+    assert_equal "B", template.render
+
+    template = Liquid::Template.parse("B\n {%- if true %}{% endif %}", bug_compatible_whitespace_trimming: true)
+    assert_equal "B", template.render
+  end
 end

--- a/test/unit/block_test.rb
+++ b/test/unit/block_test.rb
@@ -17,6 +17,7 @@ class BlockTest < MiniTest::Test
     assert_equal "", template.render
   end
 
+  # Temporary to test rollout of the fix for this bug
   def test_bug_compatible_pre_trim
     template = Liquid::Template.parse("\n {%- raw %}{% endraw %}", bug_compatible_whitespace_trimming: true)
     assert_equal "\n", template.render


### PR DESCRIPTION
to allow us to test the impact of the https://github.com/Shopify/liquid-c/pull/51 fix in an opt-in way before fully rolling it out.