### PR TITLE
Test and fix GC.compact compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: ruby
 
 rvm:
@@ -5,7 +6,8 @@ rvm:
   - 2.7
   - ruby-head
 
-sudo: false
+allow_failures:
+  - rvm: ruby-head
 
 notifications:
   disable: true

--- a/ext/liquid_c/block.c
+++ b/ext/liquid_c/block.c
@@ -176,6 +176,8 @@ void init_liquid_block()
     intern_unknown_tag_in_liquid_tag = rb_intern("unknown_tag_in_liquid_tag");
 
     cLiquidBlockBody = rb_const_get(mLiquid, rb_intern("BlockBody"));
+    rb_global_variable(&cLiquidBlockBody);
+    
     rb_define_method(cLiquidBlockBody, "c_parse", rb_block_parse, 2);
 }
 

--- a/ext/liquid_c/context.c
+++ b/ext/liquid_c/context.c
@@ -138,9 +138,13 @@ void init_liquid_context()
     id_ivar_strict_variables = rb_intern("@strict_variables");
 
     cLiquidVariableLookup = rb_const_get(mLiquid, rb_intern("VariableLookup"));
+    rb_global_variable(&cLiquidVariableLookup);
+
     cLiquidUndefinedVariable = rb_const_get(mLiquid, rb_intern("UndefinedVariable"));
+    rb_global_variable(&cLiquidUndefinedVariable);
 
     VALUE cLiquidContext = rb_const_get(mLiquid, rb_intern("Context"));
+    rb_global_variable(&cLiquidContext);
     rb_define_method(cLiquidContext, "c_evaluate", context_evaluate, 1);
     rb_define_method(cLiquidContext, "c_find_variable", context_find_variable, 2);
 }

--- a/ext/liquid_c/liquid.c
+++ b/ext/liquid_c/liquid.c
@@ -14,10 +14,19 @@ void Init_liquid_c(void)
 {
     utf8_encoding = rb_utf8_encoding();
     mLiquid = rb_define_module("Liquid");
+    rb_global_variable(&mLiquid);
+
     mLiquidC = rb_define_module_under(mLiquid, "C");
+    rb_global_variable(&mLiquidC);
+
     cLiquidSyntaxError = rb_const_get(mLiquid, rb_intern("SyntaxError"));
+    rb_global_variable(&cLiquidSyntaxError);
+
     cLiquidVariable = rb_const_get(mLiquid, rb_intern("Variable"));
+    rb_global_variable(&cLiquidVariable);
+
     cLiquidTemplate = rb_const_get(mLiquid, rb_intern("Template"));
+    rb_global_variable(&cLiquidTemplate);
 
     init_liquid_tokenizer();
     init_liquid_parser();

--- a/ext/liquid_c/parser.c
+++ b/ext/liquid_c/parser.c
@@ -184,12 +184,19 @@ void init_liquid_parser(void)
     idEvaluate = rb_intern("evaluate");
 
     cLiquidRangeLookup = rb_const_get(mLiquid, rb_intern("RangeLookup"));
+    rb_global_variable(&cLiquidRangeLookup);
+
     cRange = rb_const_get(rb_cObject, rb_intern("Range"));
+    rb_global_variable(&cRange);
+
     cLiquidVariableLookup = rb_const_get(mLiquid, rb_intern("VariableLookup"));
+    rb_global_variable(&cLiquidVariableLookup);
 
     VALUE cLiquidExpression = rb_const_get(mLiquid, rb_intern("Expression"));
+    rb_global_variable(&cLiquidExpression);
     rb_define_singleton_method(cLiquidExpression, "c_parse", rb_parse_expression, 1);
 
     vLiquidExpressionLiterals = rb_const_get(cLiquidExpression, rb_intern("LITERALS"));
+    rb_global_variable(&vLiquidExpressionLiterals);
 }
 

--- a/ext/liquid_c/tokenizer.c
+++ b/ext/liquid_c/tokenizer.c
@@ -264,6 +264,8 @@ static VALUE tokenizer_for_liquid_tag_method(VALUE self)
 void init_liquid_tokenizer()
 {
     cLiquidTokenizer = rb_define_class_under(mLiquidC, "Tokenizer", rb_cObject);
+    rb_global_variable(&cLiquidTokenizer);
+
     rb_define_alloc_func(cLiquidTokenizer, tokenizer_allocate);
     rb_define_method(cLiquidTokenizer, "initialize", tokenizer_initialize_method, 3);
     rb_define_method(cLiquidTokenizer, "shift", tokenizer_shift_method, 0);

--- a/ext/liquid_c/variable_lookup.c
+++ b/ext/liquid_c/variable_lookup.c
@@ -60,5 +60,6 @@ void init_liquid_variable_lookup()
     id_ivar_command_flags = rb_intern("@command_flags");
 
     VALUE cLiquidVariableLookup = rb_const_get(mLiquid, rb_intern("VariableLookup"));
+    rb_global_variable(&cLiquidVariableLookup);
     rb_define_method(cLiquidVariableLookup, "c_evaluate", variable_lookup_evaluate, 1);
 }

--- a/test/liquid_test.rb
+++ b/test/liquid_test.rb
@@ -9,3 +9,12 @@ test_files = FileList[File.join(liquid_test_dir, '{integration,unit}/**/*_test.r
 test_files.each do |test_file|
   require test_file
 end
+
+module GCCompactSetup
+  def setup
+    GC.compact if GC.respond_to?(:compact)
+    super
+  end
+end
+
+Minitest::Test.prepend(GCCompactSetup)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,2 +1,6 @@
 require 'minitest/autorun'
 require 'liquid/c'
+
+if GC.respond_to?(:compact)
+  GC.compact
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,2 @@
 require 'minitest/autorun'
 require 'liquid/c'
-
-if GC.respond_to?(:compact)
-  GC.compact
-end


### PR DESCRIPTION
Seems like Ruby 2.7's `GC.compact` is causing liquid-c to crash.

~~I'm still investigating at this stage.~~

Example crash without the second commit:

```
-- Crash Report log information --------------------------------------------
   See Crash Report log file under the one of following:                    
     * ~/Library/Logs/DiagnosticReports                                     
     * /Library/Logs/DiagnosticReports                                      
   for more details.                                                        
Don't forget to include the above Crash Report log file in bug reports.     

-- Control frame information -----------------------------------------------
c:0027 p:---- s:0149 e:000148 CFUNC  :c_strict_parse
c:0026 p:0022 s:0143 e:000142 METHOD /Users/byroot/src/github.com/Shopify/liquid-c/test/unit/variable_test.rb:103
c:0025 p:0006 s:0136 e:000135 BLOCK  /Users/byroot/src/github.com/Shopify/liquid-c/test/unit/variable_test.rb:62
c:0024 p:0069 s:0133 e:000132 METHOD /Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest/assertions.rb:402
c:0023 p:0127 s:0126 e:000125 METHOD /Users/byroot/src/github.com/Shopify/liquid-c/test/unit/variable_test.rb:61
c:0022 p:0019 s:0120 e:000119 BLOCK  /Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest/test.rb:98
c:0021 p:0002 s:0117 e:000116 METHOD /Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest/test.rb:195
c:0020 p:0005 s:0112 e:000111 BLOCK  /Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest/test.rb:95
c:0019 p:0015 s:0109 e:000108 METHOD /Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest.rb:270
c:0018 p:0005 s:0104 e:000103 BLOCK  /Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest/test.rb:94
c:0017 p:0030 s:0101 E:0012a0 METHOD /Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest.rb:365
c:0016 p:0045 s:0093 E:001148 METHOD /Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest/test.rb:211
c:0015 p:0004 s:0086 E:002440 METHOD /Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest/test.rb:93
c:0014 p:0008 s:0082 e:000081 METHOD /Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest.rb:1026
c:0013 p:0026 s:0075 e:000073 METHOD /Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest.rb:339
c:0012 p:0010 s:0067 e:000066 BLOCK  /Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest.rb:326 [FINISH]
c:0011 p:---- s:0063 e:000062 CFUNC  :each
c:0010 p:0006 s:0059 e:000058 BLOCK  /Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest.rb:325
c:0009 p:0030 s:0056 E:000f30 METHOD /Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest.rb:365
c:0008 p:0030 s:0048 E:000eb8 METHOD /Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest.rb:352
c:0007 p:0119 s:0041 E:001d08 METHOD /Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest.rb:324
c:0006 p:0009 s:0032 e:000031 BLOCK  /Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest.rb:164 [FINISH]
c:0005 p:---- s:0028 e:000027 CFUNC  :map
c:0004 p:0037 s:0024 e:000023 METHOD /Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest.rb:164
c:0003 p:0142 s:0015 e:000014 METHOD /Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest.rb:141
c:0002 p:0074 s:0008 E:000470 BLOCK  /Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest.rb:68 [FINISH]
c:0001 p:0000 s:0003 E:001240 (none) [FINISH]

-- Ruby level backtrace information ----------------------------------------
/Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest.rb:68:in `block in autorun'
/Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest.rb:141:in `run'
/Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest.rb:164:in `__run'
/Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest.rb:164:in `map'
/Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest.rb:164:in `block in __run'
/Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest.rb:324:in `run'
/Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest.rb:352:in `with_info_handler'
/Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest.rb:365:in `on_signal'
/Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest.rb:325:in `block in run'
/Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest.rb:325:in `each'
/Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest.rb:326:in `block (2 levels) in run'
/Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest.rb:339:in `run_one_method'
/Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest.rb:1026:in `run_one_method'
/Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest/test.rb:93:in `run'
/Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest/test.rb:211:in `with_info_handler'
/Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest.rb:365:in `on_signal'
/Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest/test.rb:94:in `block in run'
/Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest.rb:270:in `time_it'
/Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest/test.rb:95:in `block (2 levels) in run'
/Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest/test.rb:195:in `capture_exceptions'
/Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest/test.rb:98:in `block (3 levels) in run'
/Users/byroot/src/github.com/Shopify/liquid-c/test/unit/variable_test.rb:61:in `test_variable_filter_args'
/Users/byroot/.gem/ruby/2.7.1/gems/minitest-5.14.0/lib/minitest/assertions.rb:402:in `assert_raises'
/Users/byroot/src/github.com/Shopify/liquid-c/test/unit/variable_test.rb:62:in `block in test_variable_filter_args'
/Users/byroot/src/github.com/Shopify/liquid-c/test/unit/variable_test.rb:103:in `variable_parse'
/Users/byroot/src/github.com/Shopify/liquid-c/test/unit/variable_test.rb:103:in `c_strict_parse'

-- Machine register context ------------------------------------------------
 rax: 0x0000000000000000 rbx: 0x00007f859f10ec18 rcx: 0x000000000000069a
 rdx: 0x00007ffeea70d228 rdi: 0x00007f859f10ec18 rsi: 0x0000000000000097
 rbp: 0x00007ffeea70d210 rsp: 0x00007ffeea70d1d0  r8: 0x0000000000000000
  r9: 0x0000000000000010 r10: 0x00007ffeea70d9e0 r11: 0x00007f8498697a0c
 r12: 0x00007ffeea70d1d8 r13: 0x0000000000000cd1 r14: 0x00007f859f10ec18
 r15: 0x00000ff0b3e21152 rip: 0x000000010573b824 rfl: 0x0000000000010206

-- C level backtrace information -------------------------------------------
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(rb_vm_bugreport+0x96) [0x10575dac6]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(rb_bug_for_fatal_signal+0x1da) [0x10558e12a]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(sigsegv+0x5b) [0x1056bd74b]
/usr/lib/system/libsystem_platform.dylib(_sigtramp+0x1d) [0x7fff70f9c5fd]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(method_entry_get+0xa4) [0x10573b824]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(rb_callable_method_entry+0x29) [0x1057308f9]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(vm_search_method+0x1b4) [0x105741d04]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(rb_funcallv_with_cc+0x3f) [0x10573ce9f]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(rb_obj_as_string+0x46) [0x1056d5026]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(ruby__sfvextra+0x126) [0x1056c1c76]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(BSD_vfprintf+0x138a) [0x1056c31ba]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(rb_enc_vsprintf+0xb9) [0x1056c1939]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(rb_sprintf+0x98) [0x1056c5798]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(unexpected_type+0xcd) [0x10558e80d]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(rb_unexpected_type+0x2a) [0x10558d51a]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(rb_class_superclass+0x0) [0x10562b2e0]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(rb_exc_new_str+0x3c) [0x10558eb2c]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(rb_enc_raise+0x89) [0x105591dc9]
/Users/byroot/src/github.com/Shopify/liquid-c/lib/liquid_c.bundle(parser_must_consume+0x96) [0x1080bea16]
/Users/byroot/src/github.com/Shopify/liquid-c/lib/liquid_c.bundle(rb_variable_parse+0x241) [0x1080c0231]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(vm_call_cfunc+0x170) [0x10574e9d0]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(vm_exec_core+0x38df) [0x10573485f]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(rb_vm_exec+0xadc) [0x1057497ec]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(rb_yield+0xa7) [0x105742237]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(rb_ary_each+0x39) [0x1054f3b19]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(vm_call_cfunc+0x170) [0x10574e9d0]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(vm_exec_core+0x3782) [0x105734702]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(rb_vm_exec+0xadc) [0x1057497ec]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(rb_yield+0xa7) [0x105742237]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(rb_ary_collect+0xf2) [0x1054f9e82]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(vm_call_cfunc+0x170) [0x10574e9d0]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(vm_exec_core+0x3782) [0x105734702]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(rb_vm_exec+0xadc) [0x1057497ec]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(rb_proc_call+0x9f) [0x105661c9f]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(rb_ec_exec_end_proc+0x172) [0x10559c5a2]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(rb_ec_teardown+0xaf) [0x10559909f]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(rb_ec_cleanup+0x17e) [0x10559926e]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(ruby_run_node+0x5f) [0x10559956f]
/Users/byroot/.rubies/ruby-2.7.0/bin/ruby(main+0x5d) [0x1054f0d4d]
```