### PR TITLE
Remove calls to rb_global_variable on local variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,9 @@ rvm:
   - 2.7
   - ruby-head
 
-allow_failures:
-  - rvm: ruby-head
+jobs:
+  allow_failures:
+    - rvm: ruby-head
 
 notifications:
   disable: true

--- a/ext/liquid_c/context.c
+++ b/ext/liquid_c/context.c
@@ -144,7 +144,6 @@ void init_liquid_context()
     rb_global_variable(&cLiquidUndefinedVariable);
 
     VALUE cLiquidContext = rb_const_get(mLiquid, rb_intern("Context"));
-    rb_global_variable(&cLiquidContext);
     rb_define_method(cLiquidContext, "c_evaluate", context_evaluate, 1);
     rb_define_method(cLiquidContext, "c_find_variable", context_find_variable, 2);
 }

--- a/ext/liquid_c/parser.c
+++ b/ext/liquid_c/parser.c
@@ -193,7 +193,6 @@ void init_liquid_parser(void)
     rb_global_variable(&cLiquidVariableLookup);
 
     VALUE cLiquidExpression = rb_const_get(mLiquid, rb_intern("Expression"));
-    rb_global_variable(&cLiquidExpression);
     rb_define_singleton_method(cLiquidExpression, "c_parse", rb_parse_expression, 1);
 
     vLiquidExpressionLiterals = rb_const_get(cLiquidExpression, rb_intern("LITERALS"));

--- a/ext/liquid_c/variable_lookup.c
+++ b/ext/liquid_c/variable_lookup.c
@@ -60,6 +60,5 @@ void init_liquid_variable_lookup()
     id_ivar_command_flags = rb_intern("@command_flags");
 
     VALUE cLiquidVariableLookup = rb_const_get(mLiquid, rb_intern("VariableLookup"));
-    rb_global_variable(&cLiquidVariableLookup);
     rb_define_method(cLiquidVariableLookup, "c_evaluate", variable_lookup_evaluate, 1);
 }


### PR DESCRIPTION
@paracycle pointed out that we were calling `rb_global_variable` on a local variable in https://github.com/Shopify/liquid-c/pull/55/files/c4b0f0c9cb69286aa831f37e7aecb11bac9d8954#r400376684 .  I noticed a couple more and decided I would throw up a PR for removing them.