### PR TITLE
Compile variable nodes into the Liquid::C::BlockBody VM code

### DIFF
--- a/.github/workflows/liquid.yml
+++ b/.github/workflows/liquid.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         entry:
-          - { ruby: 2.4, allowed-failure: false }
+          - { ruby: 2.5, allowed-failure: false }
           - { ruby: 2.7, allowed-failure: false }
           - { ruby: ruby-head, allowed-failure: true }
     name: test (${{ matrix.entry.ruby }})

--- a/ext/liquid_c/context.c
+++ b/ext/liquid_c/context.c
@@ -3,8 +3,8 @@
 #include "variable_lookup.h"
 
 static VALUE cLiquidVariableLookup, cLiquidUndefinedVariable;
-ID id_aset, id_call, id_to_liquid, id_set_context;
-static ID id_evaluate, id_has_key, id_aref;
+ID id_aset, id_set_context;
+static ID id_has_key, id_aref;
 static ID id_ivar_scopes, id_ivar_environments, id_ivar_static_environments, id_ivar_strict_variables;
 
 VALUE context_evaluate(VALUE self, VALUE expression)
@@ -124,12 +124,9 @@ variable_found:
 
 void init_liquid_context()
 {
-    id_evaluate = rb_intern("evaluate");
-    id_call = rb_intern("call");
     id_has_key = rb_intern("key?");
     id_aset = rb_intern("[]=");
     id_aref = rb_intern("[]");
-    id_to_liquid = rb_intern("to_liquid");
     id_set_context = rb_intern("context=");
 
     id_ivar_scopes = rb_intern("@scopes");

--- a/ext/liquid_c/context.h
+++ b/ext/liquid_c/context.h
@@ -6,7 +6,7 @@ VALUE context_evaluate(VALUE self, VALUE expression);
 VALUE context_find_variable(VALUE self, VALUE key, VALUE raise_on_not_found);
 void context_maybe_raise_undefined_variable(VALUE self, VALUE key);
 
-extern ID id_aset, id_call, id_to_liquid, id_set_context;
+extern ID id_aset, id_set_context;
 
 #ifndef RB_SPECIAL_CONST_P
 // RB_SPECIAL_CONST_P added in Ruby 2.3

--- a/ext/liquid_c/extconf.rb
+++ b/ext/liquid_c/extconf.rb
@@ -7,5 +7,10 @@ compiler = RbConfig::MAKEFILE_CONFIG['CC']
 if ENV['DEBUG'] == 'true' && compiler =~ /gcc|g\+\+/
   $CFLAGS << ' -fbounds-check'
 end
+
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7.0") # added in 2.7
+  $CFLAGS << ' -DHAVE_RB_HASH_BULK_INSERT'
+end
+
 $warnflags.gsub!(/-Wdeclaration-after-statement/, "") if $warnflags
 create_makefile("liquid_c")

--- a/ext/liquid_c/lexer.h
+++ b/ext/liquid_c/lexer.h
@@ -42,5 +42,12 @@ inline static VALUE token_to_rstr(lexer_token_t token) {
     return rb_enc_str_new(token.val, token.val_end - token.val, utf8_encoding);
 }
 
+inline static VALUE token_to_rsym(lexer_token_t token) {
+    VALUE sym = rb_check_symbol_cstr(token.val, token.val_end - token.val, utf8_encoding);
+    if (RB_LIKELY(sym != Qnil))
+        return sym;
+    return rb_str_intern(token_to_rstr(token));
+}
+
 #endif
 

--- a/ext/liquid_c/liquid.c
+++ b/ext/liquid_c/liquid.c
@@ -10,6 +10,10 @@
 #include "variable_lookup.h"
 #include "vm.h"
 
+ID id_evaluate;
+ID id_to_liquid;
+ID id_call;
+
 VALUE mLiquid, mLiquidC, cLiquidSyntaxError, cMemoryError, cLiquidVariable, cLiquidTemplate, cLiquidBlockBody;
 rb_encoding *utf8_encoding;
 int utf8_encoding_index;
@@ -21,6 +25,10 @@ __attribute__((noreturn)) void raise_non_utf8_encoding_error(VALUE string, const
 
 void Init_liquid_c(void)
 {
+    id_evaluate = rb_intern("evaluate");
+    id_to_liquid = rb_intern("to_liquid");
+    id_call = rb_intern("call");
+
     utf8_encoding = rb_utf8_encoding();
     utf8_encoding_index = rb_enc_to_index(utf8_encoding);
 

--- a/ext/liquid_c/liquid.h
+++ b/ext/liquid_c/liquid.h
@@ -5,6 +5,10 @@
 #include <ruby/encoding.h>
 #include <stdbool.h>
 
+extern ID id_evaluate;
+extern ID id_to_liquid;
+extern ID id_call;
+
 extern VALUE mLiquid, mLiquidC, cLiquidSyntaxError, cMemoryError, cLiquidVariable, cLiquidTemplate, cLiquidBlockBody;
 extern rb_encoding *utf8_encoding;
 extern int utf8_encoding_index;

--- a/ext/liquid_c/parser.c
+++ b/ext/liquid_c/parser.c
@@ -130,6 +130,17 @@ static VALUE parse_variable(parser_t *p)
     return rb_class_new_instance(4, args, cLiquidVariableLookup);
 }
 
+bool will_parse_constant_expression_next(parser_t *p)
+{
+    switch (p->cur.type) {
+        case TOKEN_IDENTIFIER:
+        case TOKEN_OPEN_SQUARE:
+            return false;
+        default:
+            return true;
+    }
+}
+
 VALUE parse_expression(parser_t *p)
 {
     switch (p->cur.type) {

--- a/ext/liquid_c/parser.h
+++ b/ext/liquid_c/parser.h
@@ -15,6 +15,7 @@ lexer_token_t parser_consume(parser_t *parser, unsigned char type);
 lexer_token_t parser_consume_any(parser_t *parser);
 
 VALUE parse_expression(parser_t *parser);
+bool will_parse_constant_expression_next(parser_t *parser);
 
 void init_liquid_parser(void);
 

--- a/ext/liquid_c/variable.c
+++ b/ext/liquid_c/variable.c
@@ -3,6 +3,142 @@
 #include "parser.h"
 #include <stdio.h>
 
+static ID id_rescue_strict_parse_syntax_error;
+
+static void compile_expression(vm_assembler_t *code, VALUE expression, bool const_expression)
+{
+    if (const_expression)
+        vm_assembler_add_push_const(code, expression);
+    else
+        vm_assembler_add_push_eval_expr(code, expression);
+}
+
+static int compile_each_keyword_arg(VALUE key, VALUE value, VALUE func_arg)
+{
+    vm_assembler_t *code = (vm_assembler_t *)func_arg;
+
+    vm_assembler_add_push_const(code, key);
+
+    bool is_const_expr = !rb_respond_to(value, id_evaluate);
+    compile_expression(code, value, is_const_expr);
+
+    return ST_CONTINUE;
+}
+
+static inline void parse_and_compile_expression(parser_t *p, vm_assembler_t *code)
+{
+    bool is_const = will_parse_constant_expression_next(p);
+    compile_expression(code, parse_expression(p), is_const);
+}
+
+static VALUE try_variable_strict_parse(VALUE uncast_args)
+{
+    variable_parse_args_t *parse_args = (void *)uncast_args;
+    parser_t p;
+    init_parser(&p, parse_args->markup, parse_args->markup_end);
+    vm_assembler_t *code = parse_args->code;
+
+    if (p.cur.type == TOKEN_EOS)
+        return Qnil;
+
+    vm_assembler_add_render_variable_rescue(code, parse_args->line_number);
+
+    parse_and_compile_expression(&p, code);
+
+    while (parser_consume(&p, TOKEN_PIPE).type) {
+        lexer_token_t filter_name_token = parser_must_consume(&p, TOKEN_IDENTIFIER);
+        VALUE filter_name = token_to_rsym(filter_name_token);
+
+        size_t arg_count = 0;
+        bool const_keyword_args = true;
+        VALUE keyword_args = Qnil;
+
+        if (parser_consume(&p, TOKEN_COLON).type) {
+            do {
+                if (p.cur.type == TOKEN_IDENTIFIER && p.next.type == TOKEN_COLON) {
+                    VALUE key = token_to_rstr(parser_consume_any(&p));
+                    parser_consume_any(&p);
+
+                    if (const_keyword_args && !will_parse_constant_expression_next(&p))
+                        const_keyword_args = false;
+                    if (keyword_args == Qnil)
+                        keyword_args = rb_hash_new();
+                    rb_hash_aset(keyword_args, key, parse_expression(&p));
+                } else {
+                    parse_and_compile_expression(&p, code);
+                    arg_count++;
+                }
+            } while (parser_consume(&p, TOKEN_COMMA).type);
+        }
+
+        if (keyword_args != Qnil) {
+            arg_count++;
+            if (RHASH_SIZE(keyword_args) > 255) {
+                rb_enc_raise(utf8_encoding, cLiquidSyntaxError, "Too many filter keyword arguments");
+            }
+            if (const_keyword_args) {
+                vm_assembler_add_push_const(code, keyword_args);
+            } else {
+                rb_hash_foreach(keyword_args, compile_each_keyword_arg, (VALUE)code);
+                vm_assembler_add_hash_new(code, RHASH_SIZE(keyword_args));
+            }
+        }
+        if (arg_count > 254) {
+            rb_enc_raise(utf8_encoding, cLiquidSyntaxError, "Too many filter arguments");
+        }
+        vm_assembler_add_filter(code, filter_name, arg_count);
+    }
+
+    vm_assembler_add_pop_write_variable(code);
+
+    parser_must_consume(&p, TOKEN_EOS);
+
+    return Qnil;
+}
+
+typedef struct variable_strict_parse_rescue {
+    variable_parse_args_t *parse_args;
+    size_t instructions_size;
+    size_t constants_size;
+    size_t stack_size;
+} variable_strict_parse_rescue_t;
+
+static VALUE variable_strict_parse_rescue(VALUE uncast_args, VALUE exception)
+{
+    variable_strict_parse_rescue_t *rescue_args = (void *)uncast_args;
+    variable_parse_args_t *parse_args = rescue_args->parse_args;
+    vm_assembler_t *code = parse_args->code;
+
+    // undo partial strict parse
+    code->instructions.data_end = code->instructions.data + rescue_args->instructions_size;
+    code->constants.data_end = code->constants.data + rescue_args->constants_size;
+    code->stack_size = rescue_args->stack_size;
+
+    if (rb_obj_is_kind_of(exception, cLiquidSyntaxError) == Qfalse)
+        rb_exc_raise(exception);
+
+    VALUE markup_obj = rb_enc_str_new(parse_args->markup, parse_args->markup_end - parse_args->markup, utf8_encoding);
+    VALUE variable_obj = rb_funcall(
+        cLiquidVariable, id_rescue_strict_parse_syntax_error, 3,
+        exception, markup_obj, parse_args->parse_context
+    );
+
+    vm_assembler_add_write_node(code, variable_obj);
+    return Qnil;
+}
+
+void internal_variable_parse(variable_parse_args_t *parse_args)
+{
+    vm_assembler_t *code = parse_args->code;
+    variable_strict_parse_rescue_t rescue_args = {
+        .parse_args = parse_args,
+        .instructions_size = c_buffer_size(&code->instructions),
+        .constants_size = c_buffer_size(&code->constants),
+        .stack_size = code->stack_size,
+    };
+    rb_rescue(try_variable_strict_parse, (VALUE)parse_args, variable_strict_parse_rescue, (VALUE)&rescue_args);
+}
+
 static VALUE rb_variable_parse(VALUE self, VALUE markup, VALUE filters)
 {
     StringValue(markup);
@@ -49,6 +185,8 @@ static VALUE rb_variable_parse(VALUE self, VALUE markup, VALUE filters)
 
 void init_liquid_variable(void)
 {
+    id_rescue_strict_parse_syntax_error = rb_intern("rescue_strict_parse_syntax_error");
+
     rb_define_singleton_method(cLiquidVariable, "c_strict_parse", rb_variable_parse, 2);
 }
 

--- a/ext/liquid_c/variable.h
+++ b/ext/liquid_c/variable.h
@@ -1,7 +1,18 @@
 #if !defined(LIQUID_VARIABLE_H)
 #define LIQUID_VARIABLE_H
 
+#include "vm_assembler.h"
+
+typedef struct variable_parse_args {
+    const char *markup;
+    const char *markup_end;
+    vm_assembler_t *code;
+    VALUE parse_context;
+    unsigned int line_number;
+} variable_parse_args_t;
+
 void init_liquid_variable(void);
+void internal_variable_parse(variable_parse_args_t *parse_args);
 
 #endif
 

--- a/ext/liquid_c/vm.c
+++ b/ext/liquid_c/vm.c
@@ -3,36 +3,53 @@
 #include "liquid.h"
 #include "vm.h"
 #include "resource_limits.h"
+#include "context.h"
 
 ID id_render_node;
 ID id_ivar_interrupts;
 ID id_ivar_resource_limits;
+ID id_to_s;
 ID id_vm;
+ID id_strainer;
+ID id_filter_methods_hash;
+ID id_strict_filters;
+ID id_global_filter;
 
-VALUE cLiquidCVM;
+static VALUE cLiquidCVM;
 
 typedef struct vm {
+    c_buffer_t stack;
+    VALUE strainer;
+    VALUE filter_methods;
     VALUE interrupts;
     VALUE resource_limits_obj;
     resource_limits_t *resource_limits;
+    VALUE global_filter;
+    bool strict_filters;
 } vm_t;
 
 static void vm_mark(void *ptr)
 {
     vm_t *vm = ptr;
+    rb_gc_mark_locations((VALUE *)vm->stack.data, (VALUE *)vm->stack.data_end);
+    rb_gc_mark(vm->strainer);
+    rb_gc_mark(vm->filter_methods);
     rb_gc_mark(vm->interrupts);
     rb_gc_mark(vm->resource_limits_obj);
+    rb_gc_mark(vm->global_filter);
 }
 
 static void vm_free(void *ptr)
 {
     vm_t *vm = ptr;
+    c_buffer_free(&vm->stack);
     xfree(vm);
 }
 
 static size_t vm_memsize(const void *ptr)
 {
-    return sizeof(vm_t);
+    const vm_t *vm = ptr;
+    return sizeof(vm_t) + c_buffer_capacity(&vm->stack);
 }
 
 const rb_data_type_t vm_data_type = {
@@ -45,12 +62,22 @@ static VALUE vm_internal_new(VALUE context)
 {
     vm_t *vm;
     VALUE obj = TypedData_Make_Struct(cLiquidCVM, vm_t, &vm_data_type, vm);
+    vm->stack = c_buffer_init();
+
+    vm->strainer = rb_funcall(context, id_strainer, 0);
+    Check_Type(vm->strainer, T_OBJECT);
+
+    vm->filter_methods = rb_funcall(RBASIC_CLASS(vm->strainer), id_filter_methods_hash, 0);
+    Check_Type(vm->filter_methods, T_HASH);
 
     vm->interrupts = rb_ivar_get(context, id_ivar_interrupts);
     Check_Type(vm->interrupts, T_ARRAY);
 
     vm->resource_limits_obj = rb_ivar_get(context, id_ivar_resource_limits);;
     ResourceLimits_Get_Struct(vm->resource_limits_obj, vm->resource_limits);
+
+    vm->strict_filters = RTEST(rb_funcall(context, id_strict_filters, 0));
+    vm->global_filter = rb_funcall(context, id_global_filter, 0);
     return obj;
 }
 
@@ -61,8 +88,208 @@ static vm_t *vm_from_context(VALUE context)
         vm_obj = vm_internal_new(context);
         rb_ivar_set(context, id_vm, vm_obj);
     }
-    // instance variable is hidden from C so should be safe to unwrap it without type checking
+    // instance variable is hidden from ruby so should be safe to unwrap it without type checking
     return DATA_PTR(vm_obj);
+}
+
+static void write_fixnum(VALUE output, VALUE fixnum)
+{
+    long long number = RB_NUM2LL(fixnum);
+    int write_length = snprintf(NULL, 0, "%lld", number);
+    long old_size = RSTRING_LEN(output);
+    long new_size = old_size + write_length;
+    long capacity = rb_str_capacity(output);
+
+    if (new_size > capacity) {
+        do {
+            capacity *= 2;
+        } while (new_size > capacity);
+        rb_str_resize(output, capacity);
+    }
+    rb_str_set_len(output, new_size);
+
+    snprintf(RSTRING_PTR(output) + old_size, write_length + 1, "%lld", number);
+}
+
+static void write_obj(VALUE output, VALUE obj)
+{
+    switch (TYPE(obj)) {
+        case T_STRING:
+            rb_str_buf_append(output, obj);
+            break;
+        case T_FIXNUM:
+            write_fixnum(output, obj);
+            break;
+        case T_ARRAY:
+            for (long i = 0; i < RARRAY_LEN(obj); i++)
+            {
+                VALUE item = RARRAY_AREF(obj, i);
+
+                if (RB_UNLIKELY(RB_TYPE_P(item, T_ARRAY))) {
+                    // Normally liquid arrays are flat, but for safety and simplicity we
+                    // leverage ruby's join that detects and raises on a recursion loop
+                    rb_str_buf_append(output, rb_ary_join(item, Qnil));
+                } else {
+                    write_obj(output, item);
+                }
+            }
+            break;
+        case T_NIL:
+            break;
+        default:
+            obj = rb_funcall(obj, id_to_s, 0);
+            rb_str_append(output, obj);
+            break;
+    }
+}
+
+static inline void vm_stack_push(vm_t *vm, VALUE value)
+{
+    VALUE *stack_ptr = (VALUE *)vm->stack.data_end;
+    *stack_ptr++ = value;
+    vm->stack.data_end = (uint8_t *)stack_ptr;
+}
+
+static inline VALUE vm_stack_pop(vm_t *vm)
+{
+    VALUE *stack_ptr = (VALUE *)vm->stack.data_end;
+    stack_ptr--;
+    vm->stack.data_end = (uint8_t *)stack_ptr;
+    return *stack_ptr;
+}
+
+static inline VALUE *vm_stack_pop_n_use_in_place(vm_t *vm, size_t n)
+{
+    VALUE *stack_ptr = (VALUE *)vm->stack.data_end;
+    stack_ptr -= n;
+    vm->stack.data_end = (uint8_t *)stack_ptr;
+    return stack_ptr;
+}
+
+static inline void vm_stack_reserve_for_write(vm_t *vm, size_t num_values)
+{
+    c_buffer_reserve_for_write(&vm->stack, num_values * sizeof(VALUE));
+}
+
+static VALUE vm_invoke_filter(vm_t *vm, VALUE filter_name, int num_args, VALUE *args)
+{
+    bool not_invokable = rb_hash_lookup(vm->filter_methods, filter_name) != Qtrue;
+    if (RB_UNLIKELY(not_invokable)) {
+        if (vm->strict_filters) {
+            VALUE error_class = rb_const_get(mLiquid, rb_intern("UndefinedFilter"));
+            rb_raise(error_class, "undefined filter %"PRIsVALUE, rb_sym2str(filter_name));
+        }
+        return args[0];
+    }
+
+    VALUE result = rb_funcallv(vm->strainer, RB_SYM2ID(filter_name), num_args, args);
+    return rb_funcall(result, id_to_liquid, 0);
+}
+
+typedef struct vm_render_until_error_args {
+    vm_t *vm;
+    const uint8_t *ip; // use for initial address and to save an address for rescuing
+    const size_t *const_ptr;
+    unsigned int node_line_number;
+    VALUE context;
+    VALUE output;
+} vm_render_until_error_args_t;
+
+#ifdef HAVE_RB_HASH_BULK_INSERT
+#define hash_bulk_insert rb_hash_bulk_insert
+#else
+static void hash_bulk_insert(long argc, const VALUE *argv, VALUE hash)
+{
+    for (long i = 0; i < argc; i += 2) {
+        rb_hash_aset(hash, argv[i], argv[i + 1]);
+    }
+}
+#endif
+
+// Actually returns a bool resume_rendering value
+static VALUE vm_render_until_error(VALUE uncast_args)
+{
+    vm_render_until_error_args_t *args = (void *)uncast_args;
+    const size_t *const_ptr = args->const_ptr;
+    const uint8_t *ip = args->ip;
+    vm_t *vm = args->vm;
+    VALUE output = args->output;
+    args->ip = NULL; // used by vm_render_rescue, NULL to indicate that it isn't in a rescue block
+
+    while (true) {
+        switch (*ip++) {
+            case OP_LEAVE:
+                return false;
+
+            case OP_PUSH_CONST:
+                vm_stack_push(vm, (VALUE)*const_ptr++);
+                break;
+            case OP_HASH_NEW:
+            {
+                size_t hash_size = *ip++;
+                size_t num_keys_and_values = hash_size * 2;
+                VALUE hash = rb_hash_new();
+                VALUE *args_ptr = vm_stack_pop_n_use_in_place(vm, num_keys_and_values);
+                hash_bulk_insert(num_keys_and_values, args_ptr, hash);
+                vm_stack_push(vm, hash);
+                break;
+            }
+            case OP_FILTER:
+            {
+                VALUE filter_name = (VALUE)*const_ptr++;
+                uint8_t num_args = *ip++; // includes input argument
+                VALUE *args_ptr = vm_stack_pop_n_use_in_place(vm, num_args);
+                VALUE result = vm_invoke_filter(vm, filter_name, num_args, args_ptr);
+                vm_stack_push(vm, result);
+                break;
+            }
+            case OP_PUSH_EVAL_EXPR:
+            {
+                VALUE expression = (VALUE)*const_ptr++;
+                vm_stack_push(vm, context_evaluate(args->context, expression));
+                break;
+            }
+
+            // Rendering instructions
+
+            case OP_WRITE_RAW:
+            {
+                const char *text = (const char *)*const_ptr++;
+                size_t size = *const_ptr++;
+                rb_str_cat(output, text, size);
+                resource_limits_increment_write_score(vm->resource_limits, output);
+                break;
+            }
+            case OP_WRITE_NODE:
+                rb_funcall(cLiquidBlockBody, id_render_node, 3, args->context, output, (VALUE)*const_ptr++);
+                if (RARRAY_LEN(vm->interrupts)) {
+                    return false;
+                }
+                resource_limits_increment_write_score(vm->resource_limits, output);
+                break;
+            case OP_RENDER_VARIABLE_RESCUE:
+                // Save state used by vm_render_rescue to rescue from a variable rendering exception
+                args->node_line_number = (unsigned int)*const_ptr++;
+                // vm_render_rescue will iterate from this instruction to the instruction
+                // following OP_POP_WRITE_VARIABLE to resume rendering from
+                args->ip = ip;
+                args->const_ptr = const_ptr;
+                break;
+            case OP_POP_WRITE_VARIABLE:
+            {
+                VALUE var_result = vm_stack_pop(vm);
+                if (vm->global_filter != Qnil)
+                    var_result = rb_funcall(vm->global_filter, id_call, 1, var_result);
+                write_obj(output, var_result);
+                args->ip = NULL; // mark the end of a rescue block, used by vm_render_rescue
+                resource_limits_increment_write_score(vm->resource_limits, output);
+                break;
+            }
+
+            default:
+                rb_bug("invalid opcode: %u", ip[-1]);
+        }
+    }
 }
 
 void liquid_vm_next_instruction(const uint8_t **ip_ptr, const size_t **const_ptr_ptr)
@@ -71,9 +298,22 @@ void liquid_vm_next_instruction(const uint8_t **ip_ptr, const size_t **const_ptr
 
     switch (*ip++) {
         case OP_LEAVE:
+        case OP_POP_WRITE_VARIABLE:
+            break;
+
+        case OP_HASH_NEW:
+            ip++;
             break;
 
         case OP_WRITE_NODE:
+        case OP_PUSH_CONST:
+        case OP_PUSH_EVAL_EXPR:
+        case OP_RENDER_VARIABLE_RESCUE:
+            (*const_ptr_ptr)++;
+            break;
+
+        case OP_FILTER:
+            ip++;
             (*const_ptr_ptr)++;
             break;
 
@@ -87,37 +327,60 @@ void liquid_vm_next_instruction(const uint8_t **ip_ptr, const size_t **const_ptr
     *ip_ptr = ip;
 }
 
+typedef struct vm_render_rescue_args {
+    vm_render_until_error_args_t *render_args;
+    size_t old_stack_byte_size;
+} vm_render_rescue_args_t;
+
+// Actually returns a bool resume_rendering value
+static VALUE vm_render_rescue(VALUE uncast_args, VALUE exception)
+{
+    vm_render_rescue_args_t *args = (void *)uncast_args;
+    VALUE blank_tag = Qfalse; // tags are still rendered using Liquid::BlockBody.render_node
+    vm_render_until_error_args_t *render_args = args->render_args;
+
+    const uint8_t *ip = render_args->ip;
+    if (ip) {
+        // rescue for variable render, where ip is at the start of the render and we need to
+        // skip to the end of the variable render to resume rendering if the error is handled
+        enum opcode last_op;
+        do {
+            last_op = *ip;
+            liquid_vm_next_instruction(&ip, &render_args->const_ptr);
+        } while (last_op != OP_POP_WRITE_VARIABLE);
+        render_args->ip = ip;
+        vm_t *vm = render_args->vm;
+        // remove temporary stack values from variable evaluation
+        vm->stack.data_end = vm->stack.data + args->old_stack_byte_size;
+    }
+
+    VALUE line_number = render_args->node_line_number == 0 ? Qnil : UINT2NUM(render_args->node_line_number);
+
+    rb_funcall(cLiquidBlockBody, rb_intern("c_rescue_render_node"), 5,
+        render_args->context, render_args->output, line_number, exception, blank_tag);
+    return true;
+}
+
 void liquid_vm_render(block_body_t *body, VALUE context, VALUE output)
 {
     vm_t *vm = vm_from_context(context);
+
+    vm_stack_reserve_for_write(vm, body->code.max_stack_size);
     resource_limits_increment_render_score(vm->resource_limits, body->render_score);
 
-    const size_t *const_ptr = (const size_t *)body->code.constants.data;
-    const uint8_t *ip = body->code.instructions.data;
-    VALUE interrupts = vm->interrupts;
+    vm_render_until_error_args_t render_args = {
+        .vm = vm,
+        .const_ptr = (const size_t *)body->code.constants.data,
+        .ip = body->code.instructions.data,
+        .context = context,
+        .output = output,
+    };
+    vm_render_rescue_args_t rescue_args = {
+        .render_args = &render_args,
+        .old_stack_byte_size = c_buffer_size(&vm->stack),
+    };
 
-    while (true) {
-        switch (*ip++) {
-            case OP_LEAVE:
-                return;
-            case OP_WRITE_RAW:
-            {
-                const char *text = (const char *)*const_ptr++;
-                size_t size = *const_ptr++;
-                rb_str_cat(output, text, size);
-                break;
-            }
-            case OP_WRITE_NODE:
-                rb_funcall(cLiquidBlockBody, id_render_node, 3, context, output, (VALUE)*const_ptr++);
-                if (RARRAY_LEN(interrupts)) {
-                    return;
-                }
-                break;
-            default:
-                rb_bug("invalid opcode: %u", ip[-1]);
-        }
-
-        resource_limits_increment_write_score(vm->resource_limits, output);
+    while (rb_rescue(vm_render_until_error, (VALUE)&render_args, vm_render_rescue, (VALUE)&rescue_args)) {
     }
 }
 
@@ -127,7 +390,12 @@ void init_liquid_vm()
     id_render_node = rb_intern("render_node");
     id_ivar_interrupts = rb_intern("@interrupts");
     id_ivar_resource_limits = rb_intern("@resource_limits");
+    id_to_s = rb_intern("to_s");
     id_vm = rb_intern("vm");
+    id_strainer = rb_intern("strainer");
+    id_filter_methods_hash = rb_intern("filter_methods_hash");
+    id_strict_filters = rb_intern("strict_filters");
+    id_global_filter = rb_intern("global_filter");
 
     cLiquidCVM = rb_define_class_under(mLiquidC, "VM", rb_cObject);
     rb_undef_alloc_func(cLiquidCVM);

--- a/ext/liquid_c/vm.c
+++ b/ext/liquid_c/vm.c
@@ -7,6 +7,63 @@
 ID id_render_node;
 ID id_ivar_interrupts;
 ID id_ivar_resource_limits;
+ID id_vm;
+
+VALUE cLiquidCVM;
+
+typedef struct vm {
+    VALUE interrupts;
+    VALUE resource_limits_obj;
+    resource_limits_t *resource_limits;
+} vm_t;
+
+static void vm_mark(void *ptr)
+{
+    vm_t *vm = ptr;
+    rb_gc_mark(vm->interrupts);
+    rb_gc_mark(vm->resource_limits_obj);
+}
+
+static void vm_free(void *ptr)
+{
+    vm_t *vm = ptr;
+    xfree(vm);
+}
+
+static size_t vm_memsize(const void *ptr)
+{
+    return sizeof(vm_t);
+}
+
+const rb_data_type_t vm_data_type = {
+    "liquid_vm",
+    { vm_mark, vm_free, vm_memsize, },
+    NULL, NULL, RUBY_TYPED_FREE_IMMEDIATELY
+};
+
+static VALUE vm_internal_new(VALUE context)
+{
+    vm_t *vm;
+    VALUE obj = TypedData_Make_Struct(cLiquidCVM, vm_t, &vm_data_type, vm);
+
+    vm->interrupts = rb_ivar_get(context, id_ivar_interrupts);
+    Check_Type(vm->interrupts, T_ARRAY);
+
+    vm->resource_limits_obj = rb_ivar_get(context, id_ivar_resource_limits);;
+    ResourceLimits_Get_Struct(vm->resource_limits_obj, vm->resource_limits);
+    return obj;
+}
+
+static vm_t *vm_from_context(VALUE context)
+{
+    VALUE vm_obj = rb_attr_get(context, id_vm);
+    if (vm_obj == Qnil) {
+        vm_obj = vm_internal_new(context);
+        rb_ivar_set(context, id_vm, vm_obj);
+    }
+    // instance variable is hidden from C so should be safe to unwrap it without type checking
+    return DATA_PTR(vm_obj);
+}
 
 void liquid_vm_next_instruction(const uint8_t **ip_ptr, const size_t **const_ptr_ptr)
 {
@@ -32,15 +89,12 @@ void liquid_vm_next_instruction(const uint8_t **ip_ptr, const size_t **const_ptr
 
 void liquid_vm_render(block_body_t *body, VALUE context, VALUE output)
 {
-    resource_limits_t *resource_limits;
-    ResourceLimits_Get_Struct(rb_ivar_get(context, id_ivar_resource_limits), resource_limits);
-
-    resource_limits_increment_render_score(resource_limits, body->render_score);
+    vm_t *vm = vm_from_context(context);
+    resource_limits_increment_render_score(vm->resource_limits, body->render_score);
 
     const size_t *const_ptr = (const size_t *)body->code.constants.data;
     const uint8_t *ip = body->code.instructions.data;
-    VALUE interrupts = rb_ivar_get(context, id_ivar_interrupts);
-    Check_Type(interrupts, T_ARRAY);
+    VALUE interrupts = vm->interrupts;
 
     while (true) {
         switch (*ip++) {
@@ -63,7 +117,7 @@ void liquid_vm_render(block_body_t *body, VALUE context, VALUE output)
                 rb_bug("invalid opcode: %u", ip[-1]);
         }
 
-        resource_limits_increment_write_score(resource_limits, output);
+        resource_limits_increment_write_score(vm->resource_limits, output);
     }
 }
 
@@ -73,4 +127,9 @@ void init_liquid_vm()
     id_render_node = rb_intern("render_node");
     id_ivar_interrupts = rb_intern("@interrupts");
     id_ivar_resource_limits = rb_intern("@resource_limits");
+    id_vm = rb_intern("vm");
+
+    cLiquidCVM = rb_define_class_under(mLiquidC, "VM", rb_cObject);
+    rb_undef_alloc_func(cLiquidCVM);
+    rb_global_variable(&cLiquidCVM);
 }

--- a/ext/liquid_c/vm_assembler.c
+++ b/ext/liquid_c/vm_assembler.c
@@ -4,6 +4,8 @@ void vm_assembler_init(vm_assembler_t *code)
 {
     code->instructions = c_buffer_allocate(8);
     code->constants = c_buffer_allocate(8 * sizeof(VALUE));
+    code->max_stack_size = 0;
+    code->stack_size = 0;
 }
 
 void vm_assembler_free(vm_assembler_t *code)
@@ -22,13 +24,32 @@ void vm_assembler_gc_mark(vm_assembler_t *code)
     while (ip < end_ip) {
         switch (*ip++) {
             case OP_LEAVE:
+            case OP_POP_WRITE_VARIABLE:
                 break;
+
+            case OP_HASH_NEW:
+                ip++;
+                break;
+
+            case OP_RENDER_VARIABLE_RESCUE:
+                const_ptr++;
+                break;
+
             case OP_WRITE_RAW:
                 const_ptr += 2;
                 break;
+
             case OP_WRITE_NODE:
+            case OP_PUSH_CONST:
+            case OP_PUSH_EVAL_EXPR:
                 rb_gc_mark(*const_ptr++);
                 break;
+
+            case OP_FILTER:
+                ip++;
+                rb_gc_mark(*const_ptr++);
+                break;
+
             default:
                 rb_bug("invalid opcode: %u", ip[-1]);
         }

--- a/ext/liquid_c/vm_assembler.h
+++ b/ext/liquid_c/vm_assembler.h
@@ -1,17 +1,26 @@
 #ifndef VM_ASSEMBLER_H
 #define VM_ASSEMBLER_H
 
+#include <assert.h>
 #include "c_buffer.h"
 
 enum opcode {
     OP_LEAVE = 0,
     OP_WRITE_RAW = 1,
     OP_WRITE_NODE = 2,
+    OP_POP_WRITE_VARIABLE,
+    OP_PUSH_CONST,
+    OP_HASH_NEW, // rb_hash_new & rb_hash_bulk_insert
+    OP_FILTER,
+    OP_PUSH_EVAL_EXPR,
+    OP_RENDER_VARIABLE_RESCUE, // setup state to rescue variable rendering
 };
 
 typedef struct vm_assembler {
     c_buffer_t instructions;
     c_buffer_t constants;
+    size_t max_stack_size;
+    size_t stack_size;
 } vm_assembler_t;
 
 void vm_assembler_init(vm_assembler_t *code);
@@ -35,6 +44,14 @@ static inline void vm_assembler_write_ruby_constant(vm_assembler_t *code, VALUE 
     c_buffer_write(&code->constants, &constant, sizeof(VALUE));
 }
 
+static inline void vm_assembler_increment_stack_size(vm_assembler_t *code, size_t amount)
+{
+    code->stack_size += amount;
+    if (code->stack_size > code->max_stack_size)
+        code->max_stack_size = code->stack_size;
+}
+
+
 static inline void vm_assembler_add_leave(vm_assembler_t *code)
 {
     vm_assembler_write_opcode(code, OP_LEAVE);
@@ -43,6 +60,49 @@ static inline void vm_assembler_add_leave(vm_assembler_t *code)
 static inline void vm_assembler_remove_leave(vm_assembler_t *code)
 {
     code->instructions.data_end--;
+    assert(*code->instructions.data_end == OP_LEAVE);
+}
+
+static inline void vm_assembler_add_pop_write_variable(vm_assembler_t *code)
+{
+    code->stack_size -= 1;
+    vm_assembler_write_opcode(code, OP_POP_WRITE_VARIABLE);
+}
+
+static inline void vm_assembler_add_hash_new(vm_assembler_t *code, uint8_t hash_size)
+{
+    code->stack_size -= hash_size * 2;
+    code->stack_size++;
+    uint8_t instructions[2] = { OP_HASH_NEW, hash_size };
+    c_buffer_write(&code->instructions, &instructions, 2);
+}
+
+static inline void vm_assembler_add_push_const(vm_assembler_t *code, VALUE constant)
+{
+    vm_assembler_increment_stack_size(code, 1);
+    vm_assembler_write_ruby_constant(code, constant);
+    vm_assembler_write_opcode(code, OP_PUSH_CONST);
+}
+
+static inline void vm_assembler_add_push_eval_expr(vm_assembler_t *code, VALUE expression)
+{
+    vm_assembler_increment_stack_size(code, 1);
+    vm_assembler_write_ruby_constant(code, expression);
+    vm_assembler_write_opcode(code, OP_PUSH_EVAL_EXPR);
+}
+
+static inline void vm_assembler_add_filter(vm_assembler_t *code, VALUE filter_name, uint8_t arg_count)
+{
+    code->stack_size -= arg_count;
+    vm_assembler_write_ruby_constant(code, filter_name);
+    uint8_t instructions[2] = { OP_FILTER, arg_count + 1 /* include input */ };
+    c_buffer_write(&code->instructions, &instructions, 2);
+}
+
+static inline void vm_assembler_add_render_variable_rescue(vm_assembler_t *code, size_t node_line_number)
+{
+    c_buffer_write(&code->constants, &node_line_number, sizeof(size_t));
+    vm_assembler_write_opcode(code, OP_RENDER_VARIABLE_RESCUE);
 }
 
 #endif

--- a/liquid-c.gemspec
+++ b/liquid-c.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = ">= 2.5.0"
+
   spec.add_dependency 'liquid', '>= 3.0.0'
 
   spec.add_development_dependency 'bundler', ">= 1.5" # has bugfix for segfaulting deploys

--- a/test/liquid_test.rb
+++ b/test/liquid_test.rb
@@ -5,7 +5,11 @@ $LOAD_PATH << liquid_test_dir
 require 'test_helper'
 require 'liquid/c'
 
-test_files = FileList[File.join(liquid_test_dir, '{integration,unit}/**/*_test.rb')]
+test_files = FileList[File.join(liquid_test_dir, 'integration/**/*_test.rb')]
+
+# Test the Variable#strict_parse patch
+test_files << File.join(liquid_test_dir, 'unit/variable_unit_test.rb')
+
 test_files.each do |test_file|
   require test_file
 end

--- a/test/unit/block_test.rb
+++ b/test/unit/block_test.rb
@@ -2,10 +2,10 @@ require 'test_helper'
 
 class BlockTest < MiniTest::Test
   def test_no_allocation_of_trimmed_strings
-    template = Liquid::Template.parse("{{ -}}     {{- }}")
+    template = Liquid::Template.parse("{{ a -}}     {{- b }}")
     assert_equal 2, template.root.nodelist.size
 
-    template = Liquid::Template.parse("{{ -}} foo {{- }}")
+    template = Liquid::Template.parse("{{ a -}} foo {{- b }}")
     assert_equal 3, template.root.nodelist.size
   end
 


### PR DESCRIPTION
~~Depends on https://github.com/Shopify/liquid-c/pull/58 and https://github.com/Shopify/liquid/pull/1294~~

This is a continuation of https://github.com/Shopify/liquid-c/pull/58 that compiles the strict parseable liquid variables directly in the block body VM code for performance.

For simplicity, variables and expressions in tags do not yet leverage this VM code and the variable VM code still relies on the existing expression evaluation code (e.g. `context_evaluate` of Liquid::VariableLookup and Liquid::RangeLookup).  These will be optimized in following PR(s).

All the commits except the (currently) last one (Compile variable nodes into the Liquid::C::BlockBody VM code) are refactors:
* ~~I've moved the VM instructions and constants out of block_body_t into a vm_assembler_t struct, since we will want to embed the VM code in a future Liquid::C::Variable.  In the future, I intend to wrap the assembler in a Liquid::C::Assembler as a safe API for compiling tags from ruby code~~ (edit: extracted to https://github.com/Shopify/liquid-c/pull/69)
* ~~I changed the c_buffer struct to store pointers for the end of the data and capacity, instead of storing the sizes and capacity directly.  This is because we are mostly getting and updating the data end pointer, which is especially true in order to use this for the VM stack where we reserve space for the block and don't have to check the capacity for each write/push.~~ (edit: extracted to https://github.com/Shopify/liquid-c/pull/70)
* ~~I've also added support to c_buffer to be initialized with size 0 (without an allocation) which is the one case where we can't just double the capacity until we have the requested extra capacity.~~ (edit: extracted to https://github.com/Shopify/liquid-c/pull/70)
* I introduced a Liquid::C::VM that is attached to the Liquid::Context through an hidden instance variable, so the stack can be shared with nested blocks
* Leveraging https://github.com/Shopify/liquid/pull/1294 to only run liquid integration tests to avoid having to be fully compatible with the deprecated Liquid::BlockBody#nodelist
* ~~I've added a liquid_vm_next_instruction function to reduce duplication for code iterating instructions by using it for both Liquid::C::BlockBody#remove_blank_strings and Liquid::C::BlockBody#nodelist.  This way I can further leverage it for variable error handling.~~ (edit: extracted to https://github.com/Shopify/liquid-c/pull/72)
* Drop support for ruby 2.4 which is no longer supported upstream

The VM stack is one of the significant additions from this PR.  I chose to re-use the stack for nested blocks, which means that it needs to be expandable, hence the use of c_buffer_t for its memory allocation.  We can't globally determine the maximum stack size, since this stack could even be re-used in a template partial, but this PR does calculate the maximum stack size needed for a block body so that we can reserve stack space at the start of block body render and not have to check for sufficient capacity throughout the block body render.

Another design choice I made for this PR is to do error handling for the whole block body render, rather than for each variable render.  This way we can reduce the state saving cost of `rb_rescue` from liquid code that doesn't encounter variable render errors.  In order to recover from the exception, we just restore the stack size to what it was at the start of the block body render and iterate the instructions to jump just past the variable write.

Since the variable lookup and expression evaluation is still happen as it did before, the most significant change for performance is the filter invocation, which can happen without allocating an arguments array by leveraging the VM stack calling the filter function directly using `rb_funcallv`.  The filter `invokable?` is still being done at runtime (we need to pass filters as a parse option to do it at parse time) but is still optimized by doing the check directly from C using a hash with symbol keys.

## Benchmark

Before this PR (on the https://github.com/Shopify/liquid-c/pull/58 branch)

```
              parse:    146.972  (± 2.0%) i/s -      1.470k in  10.007250s
             render:    162.266  (± 2.5%) i/s -      1.635k in  10.081595s
     parse & render:     70.513  (± 2.8%) i/s -    708.000  in  10.047458s
```

after

```
              parse:    163.206  (± 1.8%) i/s -      1.632k in  10.002316s
             render:    172.302  (± 4.1%) i/s -      1.734k in  10.080641s
     parse & render:     78.371  (± 1.3%) i/s -    784.000  in  10.006170s
```