### PR TITLE
Implement Liquid::C::Expression to optimize expression evaluation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ require 'bundler/gem_tasks'
 require 'rake/extensiontask'
 require 'benchmark'
 
-ENV['DEBUG'] = 'true'
+ENV['DEBUG'] ||= 'true'
 ext_task = Rake::ExtensionTask.new("liquid_c")
 
 # For MacOS, generate debug information that ruby can read

--- a/ext/liquid_c/c_buffer.h
+++ b/ext/liquid_c/c_buffer.h
@@ -54,4 +54,9 @@ inline void c_buffer_rb_gc_mark(c_buffer_t *buffer)
     }
 }
 
+inline void c_buffer_concat(c_buffer_t *dest, c_buffer_t *src)
+{
+    c_buffer_write(dest, src->data, c_buffer_size(src));
+}
+
 #endif

--- a/ext/liquid_c/context.h
+++ b/ext/liquid_c/context.h
@@ -2,7 +2,6 @@
 #define LIQUID_CONTEXT_H
 
 void init_liquid_context();
-VALUE context_evaluate(VALUE self, VALUE expression);
 VALUE context_find_variable(VALUE self, VALUE key, VALUE raise_on_not_found);
 void context_maybe_raise_undefined_variable(VALUE self, VALUE key);
 

--- a/ext/liquid_c/expression.c
+++ b/ext/liquid_c/expression.c
@@ -1,0 +1,97 @@
+#include "liquid.h"
+#include "vm_assembler.h"
+#include "parser.h"
+#include "vm.h"
+#include "expression.h"
+
+VALUE cLiquidCExpression;
+
+static void expression_mark(void *ptr)
+{
+    expression_t *expression = ptr;
+    vm_assembler_gc_mark(&expression->code);
+}
+
+static void expression_free(void *ptr)
+{
+    expression_t *expression = ptr;
+    vm_assembler_free(&expression->code);
+    xfree(expression);
+}
+
+static size_t expression_memsize(const void *ptr)
+{
+    const expression_t *expression = ptr;
+    return sizeof(expression_t) + vm_assembler_alloc_memsize(&expression->code);
+}
+
+const rb_data_type_t expression_data_type = {
+    "liquid_expression",
+    { expression_mark, expression_free, expression_memsize, },
+    NULL, NULL, RUBY_TYPED_FREE_IMMEDIATELY
+};
+
+VALUE expression_new(expression_t **expression_ptr)
+{
+    expression_t *expression;
+    VALUE obj = TypedData_Make_Struct(cLiquidCExpression, expression_t, &expression_data_type, expression);
+    *expression_ptr = expression;
+    vm_assembler_init(&expression->code);
+    return obj;
+}
+
+static VALUE internal_expression_parse(parser_t *p)
+{
+    if (p->cur.type == TOKEN_EOS)
+        return Qnil;
+
+    // Avoid allocating an expression object just to wrap a constant
+    VALUE const_obj = try_parse_constant_expression(p);
+    if (const_obj != Qundef)
+        return const_obj;
+
+    expression_t *expression;
+    VALUE expr_obj = expression_new(&expression);
+
+    parse_and_compile_expression(p, &expression->code);
+    vm_assembler_add_leave(&expression->code);
+
+    return expr_obj;
+}
+
+static VALUE expression_strict_parse(VALUE klass, VALUE markup)
+{
+    StringValue(markup);
+    char *start = RSTRING_PTR(markup);
+
+    parser_t p;
+    init_parser(&p, start, start + RSTRING_LEN(markup));
+    VALUE expr_obj = internal_expression_parse(&p);
+
+    if (p.cur.type != TOKEN_EOS)
+        rb_enc_raise(utf8_encoding, cLiquidSyntaxError, "[:%s] is not a valid expression", symbol_names[p.cur.type]);
+
+    return expr_obj;
+}
+
+#define Expression_Get_Struct(obj, sval) TypedData_Get_Struct(obj, expression_t, &expression_data_type, sval)
+
+static VALUE expression_evaluate(VALUE self, VALUE context)
+{
+    expression_t *expression;
+    Expression_Get_Struct(self, expression);
+    return liquid_vm_evaluate(context, &expression->code);
+}
+
+VALUE internal_expression_evaluate(expression_t *expression, VALUE context)
+{
+    return liquid_vm_evaluate(context, &expression->code);
+}
+
+void init_liquid_expression()
+{
+    cLiquidCExpression = rb_define_class_under(mLiquidC, "Expression", rb_cObject);
+    rb_undef_alloc_func(cLiquidCExpression);
+    rb_define_singleton_method(cLiquidCExpression, "strict_parse", expression_strict_parse, 1);
+    rb_define_method(cLiquidCExpression, "evaluate", expression_evaluate, 1);
+}

--- a/ext/liquid_c/expression.h
+++ b/ext/liquid_c/expression.h
@@ -1,0 +1,19 @@
+#if !defined(LIQUID_EXPRESSION_H)
+#define LIQUID_EXPRESSION_H
+
+#include "vm_assembler.h"
+#include "parser.h"
+
+extern VALUE cLiquidCExpression;
+
+typedef struct expression {
+    vm_assembler_t code;
+} expression_t;
+
+void init_liquid_expression();
+
+VALUE expression_new(expression_t **expression_ptr);
+VALUE internal_expression_evaluate(expression_t *expression, VALUE context);
+
+#endif
+

--- a/ext/liquid_c/extconf.rb
+++ b/ext/liquid_c/extconf.rb
@@ -4,8 +4,12 @@ if RbConfig::CONFIG['host_os'] !~ /linux/ || Gem::Version.new(RUBY_VERSION) >= G
   $CFLAGS << ' -Werror'
 end
 compiler = RbConfig::MAKEFILE_CONFIG['CC']
-if ENV['DEBUG'] == 'true' && compiler =~ /gcc|g\+\+/
-  $CFLAGS << ' -fbounds-check'
+if ENV['DEBUG'] == 'true'
+  if compiler =~ /gcc|g\+\+/
+    $CFLAGS << ' -fbounds-check'
+  end
+else
+  $CFLAGS << ' -DNDEBUG'
 end
 
 if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7.0") # added in 2.7

--- a/ext/liquid_c/lexer.h
+++ b/ext/liquid_c/lexer.h
@@ -42,8 +42,19 @@ inline static VALUE token_to_rstr(lexer_token_t token) {
     return rb_enc_str_new(token.val, token.val_end - token.val, utf8_encoding);
 }
 
+inline static VALUE token_check_for_symbol(lexer_token_t token) {
+    return rb_check_symbol_cstr(token.val, token.val_end - token.val, utf8_encoding);
+}
+
+inline static VALUE token_to_rstr_leveraging_existing_symbol(lexer_token_t token) {
+    VALUE sym = token_check_for_symbol(token);
+    if (RB_LIKELY(sym != Qnil))
+        return rb_sym2str(sym);
+    return token_to_rstr(token);
+}
+
 inline static VALUE token_to_rsym(lexer_token_t token) {
-    VALUE sym = rb_check_symbol_cstr(token.val, token.val_end - token.val, utf8_encoding);
+    VALUE sym = token_check_for_symbol(token);
     if (RB_LIKELY(sym != Qnil))
         return sym;
     return rb_str_intern(token_to_rstr(token));

--- a/ext/liquid_c/liquid.c
+++ b/ext/liquid_c/liquid.c
@@ -5,6 +5,7 @@
 #include "parser.h"
 #include "raw.h"
 #include "resource_limits.h"
+#include "expression.h"
 #include "block.h"
 #include "context.h"
 #include "variable_lookup.h"
@@ -12,6 +13,7 @@
 
 ID id_evaluate;
 ID id_to_liquid;
+ID id_to_s;
 ID id_call;
 
 VALUE mLiquid, mLiquidC, cLiquidVariable, cLiquidTemplate, cLiquidBlockBody;
@@ -28,6 +30,7 @@ void Init_liquid_c(void)
 {
     id_evaluate = rb_intern("evaluate");
     id_to_liquid = rb_intern("to_liquid");
+    id_to_s = rb_intern("to_s");
     id_call = rb_intern("call");
 
     utf8_encoding = rb_utf8_encoding();
@@ -61,6 +64,7 @@ void Init_liquid_c(void)
     init_liquid_parser();
     init_liquid_raw();
     init_liquid_resource_limits();
+    init_liquid_expression();
     init_liquid_variable();
     init_liquid_block();
     init_liquid_context();

--- a/ext/liquid_c/liquid.h
+++ b/ext/liquid_c/liquid.h
@@ -7,6 +7,7 @@
 
 extern ID id_evaluate;
 extern ID id_to_liquid;
+extern ID id_to_s;
 extern ID id_call;
 
 extern VALUE mLiquid, mLiquidC, cLiquidVariable, cLiquidTemplate, cLiquidBlockBody;

--- a/ext/liquid_c/parser.h
+++ b/ext/liquid_c/parser.h
@@ -2,6 +2,7 @@
 #define LIQUID_PARSER_H
 
 #include "lexer.h"
+#include "vm_assembler.h"
 
 typedef struct parser {
     lexer_token_t cur, next;
@@ -14,8 +15,8 @@ lexer_token_t parser_must_consume(parser_t *parser, unsigned char type);
 lexer_token_t parser_consume(parser_t *parser, unsigned char type);
 lexer_token_t parser_consume_any(parser_t *parser);
 
-VALUE parse_expression(parser_t *parser);
-bool will_parse_constant_expression_next(parser_t *parser);
+void parse_and_compile_expression(parser_t *p, vm_assembler_t *code);
+VALUE try_parse_constant_expression(parser_t *p);
 
 void init_liquid_parser(void);
 

--- a/ext/liquid_c/variable_lookup.c
+++ b/ext/liquid_c/variable_lookup.c
@@ -2,51 +2,29 @@
 #include "context.h"
 
 static ID id_has_key, id_aref, id_fetch;
-static ID id_ivar_lookups, id_ivar_name, id_ivar_command_flags;
 
-VALUE variable_lookup_evaluate(VALUE self, VALUE context)
+VALUE variable_lookup_key(VALUE context, VALUE object, VALUE key, bool is_command)
 {
-    long command_flags = -1;
-    VALUE name = rb_ivar_get(self, id_ivar_name);
-    name = context_evaluate(context, name);
-
-    VALUE object = context_find_variable(context, name, Qtrue);
-
-    VALUE lookups = rb_ivar_get(self, id_ivar_lookups);
-    Check_Type(lookups, T_ARRAY);
-
-    for (long i = 0; i < RARRAY_LEN(lookups); i++) {
-        VALUE key = context_evaluate(context, RARRAY_AREF(lookups, i));
-        VALUE next_object;
-
-        if (rb_respond_to(object, id_aref) && (
-            (rb_respond_to(object, id_has_key) && rb_funcall(object, id_has_key, 1, key)) ||
-            (rb_obj_is_kind_of(key, rb_cInteger) && rb_respond_to(object, id_fetch))
-        )) {
-            next_object = rb_funcall(object, id_aref, 1, key);
-            next_object = materialize_proc(context, object, key, next_object);
-            object = value_to_liquid_and_set_context(next_object, context);
-            continue;
-        }
-
-        if (command_flags == -1) {
-            command_flags = NUM2LONG(rb_ivar_get(self, id_ivar_command_flags));
-        }
-        if (command_flags & (1 << i)) {
-            Check_Type(key, T_STRING);
-            ID intern_key = rb_intern(RSTRING_PTR(key));
-            if (rb_respond_to(object, intern_key)) {
-                next_object = rb_funcall(object, rb_intern(RSTRING_PTR(key)), 0);
-                object = value_to_liquid_and_set_context(next_object, context);
-                continue;
-            }
-        }
-
-        context_maybe_raise_undefined_variable(context, key);
-        return Qnil;
+    if (rb_respond_to(object, id_aref) && (
+        (rb_respond_to(object, id_has_key) && rb_funcall(object, id_has_key, 1, key)) ||
+        (rb_obj_is_kind_of(key, rb_cInteger) && rb_respond_to(object, id_fetch))
+    )) {
+        VALUE next_object = rb_funcall(object, id_aref, 1, key);
+        next_object = materialize_proc(context, object, key, next_object);
+        return value_to_liquid_and_set_context(next_object, context);
     }
 
-    return object;
+    if (is_command) {
+        Check_Type(key, T_STRING);
+        ID intern_key = rb_intern(RSTRING_PTR(key));
+        if (rb_respond_to(object, intern_key)) {
+            VALUE next_object = rb_funcall(object, intern_key, 0);
+            return value_to_liquid_and_set_context(next_object, context);
+        }
+    }
+
+    context_maybe_raise_undefined_variable(context, key);
+    return Qnil;
 }
 
 void init_liquid_variable_lookup()
@@ -54,11 +32,4 @@ void init_liquid_variable_lookup()
     id_has_key = rb_intern("key?");
     id_aref = rb_intern("[]");
     id_fetch = rb_intern("fetch");
-
-    id_ivar_lookups = rb_intern("@lookups");
-    id_ivar_name = rb_intern("@name");
-    id_ivar_command_flags = rb_intern("@command_flags");
-
-    VALUE cLiquidVariableLookup = rb_const_get(mLiquid, rb_intern("VariableLookup"));
-    rb_define_method(cLiquidVariableLookup, "c_evaluate", variable_lookup_evaluate, 1);
 }

--- a/ext/liquid_c/variable_lookup.h
+++ b/ext/liquid_c/variable_lookup.h
@@ -2,7 +2,7 @@
 #define LIQUID_VARIABLE_LOOKUP_H
 
 void init_liquid_variable_lookup();
-VALUE variable_lookup_evaluate(VALUE self, VALUE expression);
+VALUE variable_lookup_key(VALUE context, VALUE object, VALUE key, bool is_command);
 
 #endif
 

--- a/ext/liquid_c/vm.h
+++ b/ext/liquid_c/vm.h
@@ -8,5 +8,6 @@ void init_liquid_vm();
 void liquid_vm_render(block_body_t *block, VALUE context, VALUE output);
 void liquid_vm_next_instruction(const uint8_t **ip_ptr, const size_t **const_ptr_ptr);
 bool liquid_vm_filtering(VALUE context);
+VALUE liquid_vm_evaluate(VALUE context, vm_assembler_t *code);
 
 #endif

--- a/ext/liquid_c/vm_assembler.h
+++ b/ext/liquid_c/vm_assembler.h
@@ -11,9 +11,19 @@ enum opcode {
     OP_WRITE_NODE = 2,
     OP_POP_WRITE_VARIABLE,
     OP_PUSH_CONST,
+    OP_PUSH_NIL,
+    OP_PUSH_TRUE,
+    OP_PUSH_FALSE,
+    OP_PUSH_INT8,
+    OP_PUSH_INT16,
+    OP_FIND_STATIC_VAR,
+    OP_FIND_VAR,
+    OP_LOOKUP_CONST_KEY,
+    OP_LOOKUP_KEY,
+    OP_LOOKUP_COMMAND,
+    OP_NEW_INT_RANGE,
     OP_HASH_NEW, // rb_hash_new & rb_hash_bulk_insert
     OP_FILTER,
-    OP_PUSH_EVAL_EXPR,
     OP_RENDER_VARIABLE_RESCUE, // setup state to rescue variable rendering
 };
 
@@ -24,11 +34,14 @@ typedef struct vm_assembler {
     size_t stack_size;
 } vm_assembler_t;
 
+void init_liquid_vm_assembler();
 void vm_assembler_init(vm_assembler_t *code);
 void vm_assembler_free(vm_assembler_t *code);
 void vm_assembler_gc_mark(vm_assembler_t *code);
 void vm_assembler_add_write_raw(vm_assembler_t *code, const char *string, size_t size);
 void vm_assembler_add_write_node(vm_assembler_t *code, VALUE node);
+void vm_assembler_add_push_fixnum(vm_assembler_t *code, VALUE num);
+void vm_assembler_add_push_literal(vm_assembler_t *code, VALUE literal);
 
 static inline size_t vm_assembler_alloc_memsize(const vm_assembler_t *code)
 {
@@ -50,6 +63,18 @@ static inline void vm_assembler_increment_stack_size(vm_assembler_t *code, size_
     code->stack_size += amount;
     if (code->stack_size > code->max_stack_size)
         code->max_stack_size = code->stack_size;
+}
+
+static inline void vm_assembler_concat(vm_assembler_t *dest, vm_assembler_t *src)
+{
+    c_buffer_concat(&dest->instructions, &src->instructions);
+    c_buffer_concat(&dest->constants, &src->constants);
+
+    size_t max_src_stack_size = dest->stack_size + src->max_stack_size;
+    if (max_src_stack_size > dest->max_stack_size)
+        dest->max_stack_size = max_src_stack_size;
+
+    dest->stack_size += src->stack_size;
 }
 
 
@@ -78,6 +103,39 @@ static inline void vm_assembler_add_hash_new(vm_assembler_t *code, uint8_t hash_
     c_buffer_write(&code->instructions, &instructions, 2);
 }
 
+
+static inline void vm_assembler_add_push_nil(vm_assembler_t *code)
+{
+    vm_assembler_increment_stack_size(code, 1);
+    vm_assembler_write_opcode(code, OP_PUSH_NIL);
+}
+
+static inline void vm_assembler_add_push_true(vm_assembler_t *code)
+{
+    vm_assembler_increment_stack_size(code, 1);
+    vm_assembler_write_opcode(code, OP_PUSH_TRUE);
+}
+
+static inline void vm_assembler_add_push_false(vm_assembler_t *code)
+{
+    vm_assembler_increment_stack_size(code, 1);
+    vm_assembler_write_opcode(code, OP_PUSH_FALSE);
+}
+
+static inline void vm_assembler_add_push_int8(vm_assembler_t *code, int8_t value)
+{
+    vm_assembler_increment_stack_size(code, 1);
+    uint8_t instructions[2] = { OP_PUSH_INT8, value };
+    c_buffer_write(&code->instructions, &instructions, sizeof(instructions));
+}
+
+static inline void vm_assembler_add_push_int16(vm_assembler_t *code, int16_t value)
+{
+    vm_assembler_increment_stack_size(code, 1);
+    uint8_t instructions[3] = { OP_PUSH_INT16, value >> 8, (uint8_t)value };
+    c_buffer_write(&code->instructions, &instructions, sizeof(instructions));
+}
+
 static inline void vm_assembler_add_push_const(vm_assembler_t *code, VALUE constant)
 {
     vm_assembler_increment_stack_size(code, 1);
@@ -85,16 +143,48 @@ static inline void vm_assembler_add_push_const(vm_assembler_t *code, VALUE const
     vm_assembler_write_opcode(code, OP_PUSH_CONST);
 }
 
-static inline void vm_assembler_add_push_eval_expr(vm_assembler_t *code, VALUE expression)
+static inline void vm_assembler_add_find_static_variable(vm_assembler_t *code, VALUE key)
 {
     vm_assembler_increment_stack_size(code, 1);
-    vm_assembler_write_ruby_constant(code, expression);
-    vm_assembler_write_opcode(code, OP_PUSH_EVAL_EXPR);
+    vm_assembler_write_ruby_constant(code, key);
+    vm_assembler_write_opcode(code, OP_FIND_STATIC_VAR);
+}
+
+static inline void vm_assembler_add_find_variable(vm_assembler_t *code)
+{
+    // pop 1, push 1
+    vm_assembler_write_opcode(code, OP_FIND_VAR);
+}
+
+static inline void vm_assembler_add_lookup_const_key(vm_assembler_t *code, VALUE key)
+{
+    vm_assembler_increment_stack_size(code, 1);
+    vm_assembler_write_ruby_constant(code, key);
+    vm_assembler_write_opcode(code, OP_LOOKUP_CONST_KEY);
+}
+
+static inline void vm_assembler_add_lookup_key(vm_assembler_t *code)
+{
+    // pop 1, push 1
+    vm_assembler_write_opcode(code, OP_LOOKUP_KEY);
+}
+
+static inline void vm_assembler_add_lookup_command(vm_assembler_t *code, VALUE command)
+{
+    vm_assembler_increment_stack_size(code, 1);
+    vm_assembler_write_ruby_constant(code, command);
+    vm_assembler_write_opcode(code, OP_LOOKUP_COMMAND);
+}
+
+static inline void vm_assembler_add_new_int_range(vm_assembler_t *code)
+{
+    code->stack_size--; // pop 2, push 1
+    vm_assembler_write_opcode(code, OP_NEW_INT_RANGE);
 }
 
 static inline void vm_assembler_add_filter(vm_assembler_t *code, VALUE filter_name, uint8_t arg_count)
 {
-    code->stack_size -= arg_count;
+    code->stack_size -= arg_count; // pop arg_count + 1, push 1
     vm_assembler_write_ruby_constant(code, filter_name);
     uint8_t instructions[2] = { OP_FILTER, arg_count + 1 /* include input */ };
     c_buffer_write(&code->instructions, &instructions, 2);

--- a/lib/liquid/c.rb
+++ b/lib/liquid/c.rb
@@ -121,29 +121,6 @@ Liquid::Variable.class_eval do
       parse_context.instance_variable_set(:@error_mode, mode)
     end
   end
-
-  alias_method :ruby_lax_parse, :lax_parse
-  alias_method :ruby_strict_parse, :strict_parse
-
-  def lax_parse(markup)
-    if Liquid::C.enabled
-      begin
-        return strict_parse(markup)
-      rescue Liquid::SyntaxError
-        Liquid::Variable.call_variable_fallback_stats_callback(parse_context)
-      end
-    end
-
-    ruby_lax_parse(markup)
-  end
-
-  def strict_parse(markup)
-    if Liquid::C.enabled
-      @name = Liquid::Variable.c_strict_parse(markup, @filters = [])
-    else
-      ruby_strict_parse(markup)
-    end
-  end
 end
 
 Liquid::StrainerTemplate.class_eval do
@@ -168,20 +145,6 @@ Liquid::StrainerTemplate.class_eval do
   end
 end
 
-Liquid::VariableLookup.class_eval do
-  alias_method :ruby_initialize, :initialize
-
-  def initialize(markup, name = nil, lookups = nil, command_flags = nil)
-    if Liquid::C.enabled && markup == false
-      @name = name
-      @lookups = lookups
-      @command_flags = command_flags
-    else
-      ruby_initialize(markup)
-    end
-  end
-end
-
 Liquid::Expression.class_eval do
   class << self
     alias_method :ruby_parse, :parse
@@ -191,7 +154,7 @@ Liquid::Expression.class_eval do
 
       if Liquid::C.enabled
         begin
-          return c_parse(markup)
+          return Liquid::C::Expression.strict_parse(markup)
         rescue Liquid::SyntaxError
         end
       end
@@ -225,10 +188,6 @@ Liquid::ResourceLimits.class_eval do
   end
 end
 
-Liquid::VariableLookup.class_eval do
-  alias_method :ruby_evaluate, :evaluate
-end
-
 module Liquid
   module C
     class << self
@@ -240,12 +199,10 @@ module Liquid
           Liquid::Context.send(:alias_method, :evaluate, :c_evaluate)
           Liquid::Context.send(:alias_method, :find_variable, :c_find_variable_kwarg)
           Liquid::Raw.send(:alias_method, :parse, :c_parse)
-          Liquid::VariableLookup.send(:alias_method, :evaluate, :c_evaluate)
         else
           Liquid::Context.send(:alias_method, :evaluate, :ruby_evaluate)
           Liquid::Context.send(:alias_method, :find_variable, :ruby_find_variable)
           Liquid::Raw.send(:alias_method, :parse, :ruby_parse)
-          Liquid::VariableLookup.send(:alias_method, :evaluate, :ruby_evaluate)
         end
       end
     end

--- a/test/liquid_test.rb
+++ b/test/liquid_test.rb
@@ -6,10 +6,6 @@ require 'test_helper'
 require 'liquid/c'
 
 test_files = FileList[File.join(liquid_test_dir, 'integration/**/*_test.rb')]
-
-# Test the Variable#strict_parse patch
-test_files << File.join(liquid_test_dir, 'unit/variable_unit_test.rb')
-
 test_files.each do |test_file|
   require test_file
 end

--- a/test/unit/context_test.rb
+++ b/test/unit/context_test.rb
@@ -23,12 +23,13 @@ class ContextTest < Minitest::Test
   end
 
   def test_evaluate_works_with_variable_lookup
-    assert_equal 42, Liquid::Context.new({"var" => 42}).evaluate(Liquid::VariableLookup.new("var"))
+    assert_equal 42, Liquid::Context.new({"var" => 42}).evaluate(Liquid::C::Expression.strict_parse("var"))
   end
 
   def test_evaluating_a_variable_entirely_within_c
     context = Liquid::Context.new({"var" => 42})
-    lookup = Liquid::VariableLookup.new("var")
+    lookup = Liquid::C::Expression.strict_parse("var")
+    context.evaluate(lookup) # memoize vm_internal_new calls
 
     called_ruby_method_count = 0
     called_c_method_count = 0

--- a/test/unit/expression_test.rb
+++ b/test/unit/expression_test.rb
@@ -1,0 +1,109 @@
+require 'test_helper'
+
+class ExpressionTest < MiniTest::Test
+  def test_literals
+    assert_equal true, Liquid::C::Expression.strict_parse('true')
+    assert_equal false, Liquid::C::Expression.strict_parse('false')
+    assert_equal nil, Liquid::C::Expression.strict_parse('nil')
+    assert_equal nil, Liquid::C::Expression.strict_parse('null')
+
+    empty = Liquid::C::Expression.strict_parse('empty')
+    assert_equal '', empty
+    assert_same empty, Liquid::C::Expression.strict_parse('blank')
+  end
+
+  def test_byte_int
+    assert_equal 127, Liquid::C::Expression.strict_parse('127')
+    assert_equal -128, Liquid::C::Expression.strict_parse('-128')
+  end
+
+  def test_short_int
+    assert_equal 128, Liquid::C::Expression.strict_parse('128')
+    assert_equal -129, Liquid::C::Expression.strict_parse('-129')
+    assert_equal 32767, Liquid::C::Expression.strict_parse('32767')
+    assert_equal -32768, Liquid::C::Expression.strict_parse('-32768')
+  end
+
+  def test_float
+    assert_equal 123.4, Liquid::C::Expression.strict_parse('123.4')
+  end
+
+  def test_string
+    assert_equal "hello", Liquid::C::Expression.strict_parse('"hello"')
+    assert_equal "world", Liquid::C::Expression.strict_parse("'world'")
+  end
+
+  def test_find_static_variable
+    context = Liquid::Context.new({"x" => 123})
+    expr = Liquid::C::Expression.strict_parse('x')
+
+    assert_instance_of(Liquid::C::Expression, expr)
+    assert_equal 123, context.evaluate(expr)
+  end
+
+  def test_find_dynamic_variable
+    context = Liquid::Context.new({"x" => "y", "y" => 42})
+    expr = Liquid::C::Expression.strict_parse('[x]')
+    assert_equal 42, context.evaluate(expr)
+  end
+
+  def test_find_missing_variable
+    context = Liquid::Context.new({})
+    expr = Liquid::C::Expression.strict_parse('missing')
+
+    assert_nil context.evaluate(expr)
+
+    context.strict_variables = true
+
+    assert_raises(Liquid::UndefinedVariable) do
+      context.evaluate(expr)
+    end
+  end
+
+  def test_lookup_const_key
+    context = Liquid::Context.new({"obj" => { "prop" => "some value" }})
+
+    expr = Liquid::C::Expression.strict_parse('obj.prop')
+    assert_equal 'some value', context.evaluate(expr)
+
+    expr = Liquid::C::Expression.strict_parse('obj["prop"]')
+    assert_equal 'some value', context.evaluate(expr)
+  end
+
+  def test_lookup_variable_key
+    context = Liquid::Context.new({"field_name" => "prop", "obj" => { "prop" => "another value" }})
+    expr = Liquid::C::Expression.strict_parse('obj[field_name]')
+    assert_equal 'another value', context.evaluate(expr)
+  end
+
+  def test_lookup_command
+    context = Liquid::Context.new({"ary" => ['a', 'b', 'c']})
+    assert_equal 3, context.evaluate(Liquid::C::Expression.strict_parse('ary.size'))
+    assert_equal 'a', context.evaluate(Liquid::C::Expression.strict_parse('ary.first'))
+    assert_equal 'c', context.evaluate(Liquid::C::Expression.strict_parse('ary.last'))
+  end
+
+  def test_lookup_missing_key
+    context = Liquid::Context.new({ 'obj' => {} })
+    expr = Liquid::C::Expression.strict_parse('obj.missing')
+
+    assert_nil context.evaluate(expr)
+
+    context.strict_variables = true
+
+    assert_raises(Liquid::UndefinedVariable) do
+      context.evaluate(expr)
+    end
+  end
+
+  def test_const_range
+    assert_equal (1..2), Liquid::C::Expression.strict_parse('(1..2)')
+  end
+
+  def test_dynamic_range
+    context = Liquid::Context.new({"var" => 42})
+    expr = Liquid::C::Expression.strict_parse('(1..var)')
+    assert_instance_of(Liquid::C::Expression, expr)
+    assert_equal (1..42), context.evaluate(expr)
+  end
+end

--- a/test/unit/variable_test.rb
+++ b/test/unit/variable_test.rb
@@ -3,69 +3,91 @@ require 'test_helper'
 
 class VariableTest < Minitest::Test
   def test_variable_parse
-    assert_equal [lookup('hello'), []], variable_parse('hello')
-    assert_equal ['world', []], variable_parse(' "world" ')
-    assert_equal [lookup('hello["world"]'), []], variable_parse(' hello["world"] ')
-    assert_equal [nil, []], variable_parse('')
-    assert_equal [lookup('question?'), []], variable_parse('question?')
-    assert_equal [lookup('[meta]'), []], variable_parse('[meta]')
-    assert_equal [lookup('a-b'), []], variable_parse('a-b')
-    assert_equal [lookup('a-2'), []], variable_parse('a-2')
+    assert_equal 'world', variable_strict_parse("hello").render!({ 'hello' => 'world' })
+    assert_equal 'world', variable_strict_parse('"world"').render!
+    assert_equal 'answer', variable_strict_parse('hello["world"]').render!({ 'hello' => { 'world' => "answer" } })
+    assert_equal 'answer', variable_strict_parse('question?').render!({ 'question?' => "answer" })
+    assert_equal 'value', variable_strict_parse('[meta]').render!({ 'meta' => 'key', 'key' => "value" })
+    assert_equal 'result', variable_strict_parse('a-b').render!({ 'a-b' => 'result' })
+    assert_equal 'result', variable_strict_parse('a-2').render!({ 'a-2' => 'result' })
   end
 
   def test_strictness
-    assert_raises(Liquid::SyntaxError) { variable_parse(' hello["world\']" ') }
-    assert_raises(Liquid::SyntaxError) { variable_parse('-..') }
-    assert_raises(Liquid::SyntaxError) { variable_parse('question?mark') }
-    assert_raises(Liquid::SyntaxError) { variable_parse('123.foo') }
-    assert_raises(Liquid::SyntaxError) { variable_parse(' | nothing') }
+    assert_raises(Liquid::SyntaxError) { variable_strict_parse(' hello["world\']" ') }
+    assert_raises(Liquid::SyntaxError) { variable_strict_parse(' -..') }
+    assert_raises(Liquid::SyntaxError) { variable_strict_parse('question?mark') }
+    assert_raises(Liquid::SyntaxError) { variable_strict_parse('123.foo') }
+    assert_raises(Liquid::SyntaxError) { variable_strict_parse(' | nothing') }
 
     ['a .b', 'a. b', 'a . b'].each do |var|
-      assert_raises(Liquid::SyntaxError) { variable_parse(var) }
+      assert_raises(Liquid::SyntaxError) { variable_strict_parse(var) }
     end
 
     ['a -b', 'a- b', 'a - b'].each do |var|
-      assert_raises(Liquid::SyntaxError) { variable_parse(var) }
+      assert_raises(Liquid::SyntaxError) { variable_strict_parse(var) }
     end
   end
 
   def test_literals
-    assert_equal [true, []], variable_parse('true')
-    assert_equal [nil, []], variable_parse('nil')
-    assert_equal [123.4, []], variable_parse('123.4')
+    assert_equal "", variable_strict_parse('').render!
+    assert_equal "true", variable_strict_parse('true').render!
+    assert_equal "", variable_strict_parse('nil').render!
+    assert_equal "123.4", variable_strict_parse('123.4').render!
 
-    assert_equal [lookup('[blank]'), []], variable_parse('[blank]')
-    assert_equal [lookup(false, true, [Liquid::Expression::LITERALS['blank']], 0), []], variable_parse('[true][blank]')
-    assert_equal [lookup('[true][blank]'), []], variable_parse('[true][blank]')
-    assert_equal [lookup('x["size"]'), []], variable_parse('x["size"]')
+    assert_equal 'blank_value', variable_strict_parse('[blank]').render!({ '' => 'blank_value' })
+    assert_equal 'result', variable_strict_parse('[true][blank]').render!({ true => { '' => 'result' } })
+    assert_equal 'result', variable_strict_parse('x["size"]').render!({ 'x' => { 'size' => 'result' } })
+  end
+
+  module InspectCallFilters
+    def filter1(input, *args)
+      inspect_call(__method__, input, args)
+    end
+
+    def filter2(input, *args)
+      inspect_call(__method__, input, args)
+    end
+
+    private
+
+    def inspect_call(filter_name, input, args)
+      "{ filter: #{filter_name.inspect}, input: #{input.inspect}, args: #{args.inspect} }"
+    end
   end
 
   def test_variable_filter
-    name = lookup('name')
-    assert_equal [name, [['filter', []]]], variable_parse(' name | filter ')
-    assert_equal [name, [['filter1', []], ['filter2', []]]], variable_parse(' name | filter1 | filter2 ')
+    context = { 'name' => 'Bob' }
+
+    filter1_output = variable_strict_parse('name | filter1').render!(context, filters: [InspectCallFilters])
+    assert_equal '{ filter: :filter1, input: "Bob", args: [] }', filter1_output
+
+    filter2_output = variable_strict_parse('name | filter1 | filter2').render!(context, filters: [InspectCallFilters])
+    assert_equal "{ filter: :filter2, input: #{filter1_output.inspect}, args: [] }", filter2_output
   end
 
   def test_variable_filter_args
-    name = lookup('name')
-    abc = lookup('abc')
+    context = { 'name' => 'Bob', 'abc' => 'xyz' }
+    render_opts = { filters: [InspectCallFilters] }
 
-    assert_equal [name, [['filter', [abc]]]], variable_parse(' name | filter: abc ')
+    filter1_output = variable_strict_parse('name | filter1: abc').render!(context, render_opts)
+    assert_equal '{ filter: :filter1, input: "Bob", args: ["xyz"] }', filter1_output
 
-    assert_equal [name, [['filter1', [abc]], ['filter2', [abc]]]],
-      variable_parse(' name | filter1: abc | filter2: abc ')
+    filter2_output = variable_strict_parse('name | filter1: abc | filter2: abc').render!(context, render_opts)
+    assert_equal "{ filter: :filter2, input: #{filter1_output.inspect}, args: [\"xyz\"] }", filter2_output
 
-    assert_equal [name, [['filter', [lookup('a')], {'b' => lookup('c'), 'd' => lookup('e')}]]],
-      variable_parse('name | filter : a , b : c , d : e')
+    context = { 'name' => 'Bob', 'a' => 1, 'c' => 3, 'e' => 5 }
+
+    output = variable_strict_parse('name | filter1 : a , b : c , d : e').render!(context, render_opts)
+    assert_equal '{ filter: :filter1, input: "Bob", args: [1, {"b"=>3, "d"=>5}] }', output
 
     assert_raises Liquid::SyntaxError do
-      variable_parse('name | filter : a : b : c : d : e')
+      variable_strict_parse('name | filter : a : b : c : d : e')
     end
   end
 
   def test_unicode_strings
-    assert_equal ['å߀êùｉｄｈｔлｓԁѵ߀ｒáƙìｓｔɦｅƅêｓｔｐｃｍáѕｔｅｒｒãｃêｃհèｒｒ', []],
-      variable_parse('"å߀êùｉｄｈｔлｓԁѵ߀ｒáƙìｓｔɦｅƅêｓｔｐｃｍáѕｔｅｒｒãｃêｃհèｒｒ"')
+    string_content = 'å߀êùｉｄｈｔлｓԁѵ߀ｒáƙìｓｔɦｅƅêｓｔｐｃｍáѕｔｅｒｒãｃêｃհèｒｒ'
+    assert_equal string_content, variable_strict_parse("\"#{string_content}\"").render!
   end
 
   def test_broken_unicode_errors
@@ -83,10 +105,10 @@ class VariableTest < Minitest::Test
       variable_fallback: lambda { variable_fallbacks += 1 }
     }
 
-    create_variable('abc', error_mode: :lax, stats_callbacks: callbacks)
+    Liquid::Template.parse('{{abc}}', error_mode: :lax, stats_callbacks: callbacks)
     assert_equal 0, variable_fallbacks
 
-    create_variable('@!#', error_mode: :lax, stats_callbacks: callbacks)
+    Liquid::Template.parse('{{@!#}}', error_mode: :lax, stats_callbacks: callbacks)
     assert_equal 1, variable_fallbacks
   end
 
@@ -190,16 +212,7 @@ class VariableTest < Minitest::Test
 
   private
 
-  def create_variable(markup, options={})
-    Liquid::Variable.new(markup, Liquid::ParseContext.new(options))
-  end
-
-  def variable_parse(markup)
-    name = Liquid::Variable.c_strict_parse(markup, filters = [])
-    [name, filters]
-  end
-
-  def lookup(*args)
-    Liquid::VariableLookup.new(*args)
+  def variable_strict_parse(markup)
+    Liquid::Template.parse("{{#{markup}}}", error_mode: :strict)
   end
 end


### PR DESCRIPTION
~~Depends on https://github.com/Shopify/liquid-c/pull/59 and https://github.com/Shopify/liquid/pull/1300~~

## Problem

In https://github.com/Shopify/liquid-c/pull/59, expressions were compiled to ruby constants or lookup ruby objects (Liquid::VariableLookup & Liquid::RangeLookup) that are evaluated with `context_evaluate`.  This was done in that PR for simplicity, but they should really be compiled to more granular VM instructions for rendering performance and for serializability (for future caching of VM compiled templates).

## Solution

I replaced the previous code for strict parsing expressions and variable lookups to instead emit VM code, which is now compiled directly into Liquid::C::BlockBody objects when compiling variables.  Expressions are also often parsed and evaluated independent of Liquid::Variable in tags, so I introduced a `Liquid::C::Expression` object that gets returned from `Liquid::Expression.parse` if the expression includes a variable lookup and strict parsing of it succeeds.  I ended up doing both of these in the same commit, since I also leverage the `Liquid::C::Expression` object for filter keyword argument parsing to handle automatic cleanup on a parse exception.

Note that a couple of direct uses of `Liquid::Variable.new` (in assign and echo tags) no longer leverage liquid-c for parsing, which slightly impacts parse speed.  I'll embed those tags in the liquid VM code in a follow-up PR rather than introducing a Liquid::C::Variable class.  This PR significantly speeds up rendering, as shown in the benchmarks, which more than makes up for this parsing regression.

Since `Liquid::Variable.new` is no longer monkey patched and `Liquid::Expression.parse` no longer turns a comparable object, I had to update the liquid-c variable unit tests so they are tested through normal template parsing and rendering like an integration test.  I also stopped testing against the liquid gem's variable unit tests for the same reasons.

To help with detecting and debugging VM stack underflows or overflows, I added some assertions that are enabled by default for CI and gem development but are disabled by default for gem installation.

## Benchmarks

Before this PR (on the https://github.com/Shopify/liquid-c/pull/59 branch)

```
              parse:    167.388  (± 2.4%) i/s -      1.680k in  10.043356s
             render:    173.196  (± 3.5%) i/s -      1.734k in  10.022222s
     parse & render:     80.409  (± 1.2%) i/s -    808.000  in  10.050380s
```

after

```
              parse:    162.660  (± 2.5%) i/s -      1.632k in  10.040800s
             render:    231.388  (± 4.3%) i/s -      2.323k in  10.059088s
     parse & render:     86.735  (± 1.2%) i/s -    872.000  in  10.056157s
```