### PR TITLE
Avoid an expression match on a dynamic variable

### DIFF
--- a/ext/liquid_c/parser.c
+++ b/ext/liquid_c/parser.c
@@ -88,11 +88,13 @@ static VALUE parse_variable(parser_t *p)
 {
     VALUE name, lookups = rb_ary_new(), lookup;
     unsigned long long command_flags = 0;
+    bool static_variable_name = false;
 
     if (parser_consume(p, TOKEN_OPEN_SQUARE).type) {
         name = parse_expression(p);
         parser_must_consume(p, TOKEN_CLOSE_SQUARE);
     } else {
+        static_variable_name = true;
         name = token_to_rstr(parser_must_consume(p, TOKEN_IDENTIFIER));
     }
 
@@ -119,7 +121,7 @@ static VALUE parse_variable(parser_t *p)
         }
     }
 
-    if (RARRAY_LEN(lookups) == 0) {
+    if (RARRAY_LEN(lookups) == 0 && static_variable_name) {
         VALUE literal = rb_hash_lookup2(vLiquidExpressionLiterals, name, Qundef);
         if (literal != Qundef) return literal;
     }


### PR DESCRIPTION
## Problem

https://github.com/Shopify/liquid/pull/1300 introduced an error in liquid-c's unit tests:

```
  1) Failure:
VariableTest#test_literals [/Users/dylants/src/liquid-c/test/unit/variable_test.rb:37]:
--- expected
+++ actual
@@ -1 +1 @@
-[#<Liquid::VariableLookup:0xXXXXXX @name="", @lookups=[], @command_flags=0>, []]
+[nil, []]
```

Which is basically saying that `[blank]` is being parsed as having a `nil` expression instead of being the expected variable lookup for a blank string.

The problem is that an `Expression::LITERALS` lookup was being done twice on a square bracket variable lookup in liquid-c, once on the expression inside the square brackets (`blank`) and another time on the resulting expression.  Only the former is done by the liquid gem (in `Expression.parse`).

https://github.com/Shopify/liquid/pull/1300 caused this test to fail because there is an Expression::LITERALS mapping `"blank" => ""` and another mapping `"" => nil`.  Previously, the first lookup would return a `MethodLiteral` object, which there wasn't a second mapping for in `Expression::LITERALS`.

Note that the assign tag doesn't even allow a variable to be assigned with an empty string for a name, it requires at least one character for the name.

## Solution

Use a boolean flag to make sure we are only doing this `Expression::LITERALS` lookup when we haven't just parsed square brackets around the variable name.

Note that https://github.com/Shopify/liquid-c/pull/60 will remove parse_variable method, which is why I wasn't seeing the failure when testing on that liquid-c branch.