### PR TITLE
Add c_profile rake tasks for MacOS, using the Xcode instruments command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ tmp
 *.bundle
 ext/*/Makefile
 *.so
+instruments*.trace
+*.cpu
+*.object

--- a/Rakefile
+++ b/Rakefile
@@ -45,6 +45,13 @@ namespace :benchmark do
   end
 end
 
+namespace :c_profile do
+  %i(run compile render).each do |task_name|
+    task(task_name) do
+      ruby "./performance/c_profile.rb #{task_name}"
+    end
+  end
+end
 
 namespace :profile do
   desc "Run the liquid profile/performance coverage"

--- a/performance/c_profile.rb
+++ b/performance/c_profile.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'liquid'
+require 'liquid/c'
+liquid_lib_dir = $LOAD_PATH.detect{ |p| File.exists?(File.join(p, 'liquid.rb')) }
+require File.join(File.dirname(liquid_lib_dir), "performance/theme_runner")
+
+TASK_NAMES = %w(run compile render)
+task_name = ARGV.first || 'run'
+unless TASK_NAMES.include?(task_name)
+  raise "Unsupported task '#{task_name}' (must be one of #{TASK_NAMES})"
+end
+task = ThemeRunner.new.method(task_name)
+
+runner_id = fork do
+  end_time = Time.now + 5.0
+  until Time.now >= end_time
+    task.call
+  end
+end
+
+profiler_pid = spawn "instruments -t 'Time Profiler' -p #{runner_id}"
+
+Process.waitpid(runner_id)
+Process.waitpid(profiler_pid)


### PR DESCRIPTION
## Problem

As we move more code into C, we will have less visibility into where time is being spent from the ruby profile.

## Solution

Add c_profile rake tasks that uses the `instruments` Xcode command.  I added separate tasks to this `c_profile` namespace for `compile`, `render` and `run` (compile and render).  These leverage the same ThemeRunner that the `profile:run` task uses, which is defined in the liquid gem.