### PR TITLE
Generate *.dSYM debug files for MacOS in development for C line numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ ext/*/Makefile
 instruments*.trace
 *.cpu
 *.object
+*.dSYM

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,20 @@ require 'rake/extensiontask'
 require 'benchmark'
 
 ENV['DEBUG'] = 'true'
-Rake::ExtensionTask.new("liquid_c")
+ext_task = Rake::ExtensionTask.new("liquid_c")
+
+# For MacOS, generate debug information that ruby can read
+dsymutil = RbConfig::CONFIG['dsymutil']
+if !dsymutil.to_s.empty?
+  ext_lib_path = "lib/#{ext_task.binary}"
+  dsym_path = "#{ext_lib_path}.dSYM"
+
+  file dsym_path => [ext_lib_path] do
+    sh dsymutil, ext_lib_path
+  end
+  Rake::Task['compile'].enhance([dsym_path])
+end
+
 
 task :default => :test
 


### PR DESCRIPTION
## Problem

When ruby crashes, it dumps both a ruby and C backtrace.  In MacOS, the C backtrace is missing line numbers for the C extension library (`lib/liquid_c.bundle`).

Note that this wasn't a problem when using a lldb to debug, so it wasn't that it wasn't being compiled without debugging information, but ruby wasn't able to recognize it.

It turns out that the Mach-O object files normally contain the debugging information for development to avoid having combine it as part of the link step, and a separate post link step (using `dsymutil`) is needed to combine them into a `*.dSYM` directory of files for use with an installed library.  Ruby has support for reading the debugging information from the `*.dSYM` files, but not from the object files, so a POSTLINK step is used in the Makefile generated for compiling ruby to provide C line numbers on a crash:

```
POSTLINK = dsymutil $@; { test -z '$(RUBY_CODESIGN)' || codesign -s '$(RUBY_CODESIGN)' -f $@; }
```

Unfortunately, the Makefile generated for ruby extensions doesn't include this `POSTLINK` step.  Also, even if it did, the `rake-compiler` gem used to compile this extension will also need updating to copy the `*.dSYM` directory along with `liquid_c.bundle` into the `lib` directory.

## Solution

I've extended the `compile` rake task to use `dsymutil`, when it is available, until this can be fixed properly and released upstream in ruby's `mkmf` library and the `rake-compiler` gem.