### PR TITLE
Ensure template source and output strings are UTF-8 encoded

### DIFF
--- a/ext/liquid_c/block.c
+++ b/ext/liquid_c/block.c
@@ -287,6 +287,10 @@ static VALUE block_body_render_to_output_buffer(VALUE self, VALUE context, VALUE
 {
     block_body_t *body;
     BlockBody_Get_Struct(self, body);
+
+    Check_Type(output, T_STRING);
+    check_utf8_encoding(output, "output");
+
     liquid_vm_render(body, context, output);
     return output;
 }

--- a/ext/liquid_c/liquid.c
+++ b/ext/liquid_c/liquid.c
@@ -10,10 +10,18 @@
 
 VALUE mLiquid, mLiquidC, cLiquidSyntaxError, cLiquidVariable, cLiquidTemplate, cLiquidBlockBody;
 rb_encoding *utf8_encoding;
+int utf8_encoding_index;
+
+__attribute__((noreturn)) void raise_non_utf8_encoding_error(const char *value_name)
+{
+    rb_raise(rb_eEncCompatError, "non-UTF8 encoded %s (ASCII-8BIT) not supported", value_name);
+}
 
 void Init_liquid_c(void)
 {
     utf8_encoding = rb_utf8_encoding();
+    utf8_encoding_index = rb_enc_to_index(utf8_encoding);
+
     mLiquid = rb_define_module("Liquid");
     rb_global_variable(&mLiquid);
 

--- a/ext/liquid_c/liquid.h
+++ b/ext/liquid_c/liquid.h
@@ -7,6 +7,15 @@
 
 extern VALUE mLiquid, mLiquidC, cLiquidSyntaxError, cLiquidVariable, cLiquidTemplate, cLiquidBlockBody;
 extern rb_encoding *utf8_encoding;
+extern int utf8_encoding_index;
+
+__attribute__((noreturn)) void raise_non_utf8_encoding_error(const char *string_name);
+
+inline void check_utf8_encoding(VALUE string, const char *string_name)
+{
+    if (RB_UNLIKELY(RB_ENCODING_GET_INLINED(string) != utf8_encoding_index))
+        raise_non_utf8_encoding_error(string_name);
+}
 
 #ifndef RB_LIKELY
 // RB_LIKELY added in Ruby 2.4

--- a/ext/liquid_c/tokenizer.c
+++ b/ext/liquid_c/tokenizer.c
@@ -45,6 +45,8 @@ static VALUE tokenizer_initialize_method(VALUE self, VALUE source, VALUE start_l
     tokenizer_t *tokenizer;
 
     Check_Type(source, T_STRING);
+    check_utf8_encoding(source, "source");
+
     Tokenizer_Get_Struct(self, tokenizer);
     source = rb_str_dup_frozen(source);
     tokenizer->source = source;

--- a/ext/liquid_c/vm.c
+++ b/ext/liquid_c/vm.c
@@ -14,8 +14,6 @@ ID id_raise_limits_reached;
 
 void liquid_vm_render(block_body_t *body, VALUE context, VALUE output)
 {
-    Check_Type(output, T_STRING);
-
     VALUE resource_limits = rb_ivar_get(context, id_ivar_resource_limits);
     rb_funcall(resource_limits, id_increment_render_score, 1, INT2NUM(body->render_score));
 

--- a/test/unit/block_test.rb
+++ b/test/unit/block_test.rb
@@ -8,30 +8,4 @@ class BlockTest < MiniTest::Test
     template = Liquid::Template.parse("{{ -}} foo {{- }}")
     assert_equal 3, template.root.nodelist.size
   end
-
-  def test_pre_trim
-    template = Liquid::Template.parse("\n{%- raw %}{% endraw %}")
-    assert_equal "", template.render
-
-    template = Liquid::Template.parse("\n{%- if true %}{% endif %}")
-    assert_equal "", template.render
-  end
-
-  # Temporary to test rollout of the fix for this bug
-  def test_bug_compatible_pre_trim
-    template = Liquid::Template.parse("\n {%- raw %}{% endraw %}", bug_compatible_whitespace_trimming: true)
-    assert_equal "\n", template.render
-
-    template = Liquid::Template.parse("\n {%- if true %}{% endif %}", bug_compatible_whitespace_trimming: true)
-    assert_equal "\n", template.render
-
-    template = Liquid::Template.parse("{{ 'B' }} \n{%- if true %}C{% endif %}", bug_compatible_whitespace_trimming: true)
-    assert_equal "B C", template.render
-
-    template = Liquid::Template.parse("B\n {%- raw %}{% endraw %}", bug_compatible_whitespace_trimming: true)
-    assert_equal "B", template.render
-
-    template = Liquid::Template.parse("B\n {%- if true %}{% endif %}", bug_compatible_whitespace_trimming: true)
-    assert_equal "B", template.render
-  end
 end

--- a/test/unit/block_test.rb
+++ b/test/unit/block_test.rb
@@ -8,4 +8,19 @@ class BlockTest < MiniTest::Test
     template = Liquid::Template.parse("{{ -}} foo {{- }}")
     assert_equal 3, template.root.nodelist.size
   end
+
+  def test_raise_on_output_with_non_utf8_encoding
+    output = String.new(encoding: Encoding::BINARY)
+    template = Liquid::Template.parse("ascii text")
+    exc = assert_raises(Encoding::CompatibilityError) do
+      template.render!({}, output: output)
+    end
+    assert_equal("non-UTF8 encoded output (ASCII-8BIT) not supported", exc.message)
+  end
+
+  def test_write_unicode_characters
+    output = String.new(encoding: Encoding::UTF_8)
+    template = Liquid::Template.parse("ü{{ unicode_char }}")
+    assert_equal("üñ", template.render!({ 'unicode_char' => 'ñ' }, output: output))
+  end
 end

--- a/test/unit/tokenizer_test.rb
+++ b/test/unit/tokenizer_test.rb
@@ -45,6 +45,14 @@ class TokenizerTest < Minitest::Test
     assert_equal [source], output
   end
 
+  def test_non_utf8_encoded_template
+    source = String.new('ascii text', encoding: Encoding::BINARY)
+    exc = assert_raises(Encoding::CompatibilityError) do
+      Liquid::C::Tokenizer.new(source, 1, false)
+    end
+    assert_equal("non-UTF8 encoded source (ASCII-8BIT) not supported", exc.message)
+  end
+
   private
 
   def tokenize(source, for_liquid_tag: false, trimmed: false)


### PR DESCRIPTION
Fixes https://github.com/Shopify/liquid-c/issues/65

When one ruby string is appended to another, ruby will automatically do encoding conversion as long as the two strings are compatible.  This actually hides bugs in unicode character handling when testing with ascii compatible, leading to the issue this PR fixes.

Instead, I would like liquid-c to be stricter than ruby about the encoding of the input strings, so we can catch encoding errors easier during testing.  This PR simply checks to make sure the source and output encodings are exactly UTF-8 encoded and raises if they aren't.