### PR TITLE
Fix hard coding of the encoding in the error message

### DIFF
--- a/ext/liquid_c/liquid.c
+++ b/ext/liquid_c/liquid.c
@@ -12,9 +12,9 @@ VALUE mLiquid, mLiquidC, cLiquidSyntaxError, cLiquidVariable, cLiquidTemplate, c
 rb_encoding *utf8_encoding;
 int utf8_encoding_index;
 
-__attribute__((noreturn)) void raise_non_utf8_encoding_error(const char *value_name)
+__attribute__((noreturn)) void raise_non_utf8_encoding_error(VALUE string, const char *value_name)
 {
-    rb_raise(rb_eEncCompatError, "non-UTF8 encoded %s (ASCII-8BIT) not supported", value_name);
+    rb_raise(rb_eEncCompatError, "non-UTF8 encoded %s (%"PRIsVALUE") not supported", value_name, rb_obj_encoding(string));
 }
 
 void Init_liquid_c(void)

--- a/ext/liquid_c/liquid.h
+++ b/ext/liquid_c/liquid.h
@@ -9,12 +9,12 @@ extern VALUE mLiquid, mLiquidC, cLiquidSyntaxError, cLiquidVariable, cLiquidTemp
 extern rb_encoding *utf8_encoding;
 extern int utf8_encoding_index;
 
-__attribute__((noreturn)) void raise_non_utf8_encoding_error(const char *string_name);
+__attribute__((noreturn)) void raise_non_utf8_encoding_error(VALUE string, const char *string_name);
 
 inline void check_utf8_encoding(VALUE string, const char *string_name)
 {
     if (RB_UNLIKELY(RB_ENCODING_GET_INLINED(string) != utf8_encoding_index))
-        raise_non_utf8_encoding_error(string_name);
+        raise_non_utf8_encoding_error(string, string_name);
 }
 
 #ifndef RB_LIKELY

--- a/test/unit/block_test.rb
+++ b/test/unit/block_test.rb
@@ -10,12 +10,12 @@ class BlockTest < MiniTest::Test
   end
 
   def test_raise_on_output_with_non_utf8_encoding
-    output = String.new(encoding: Encoding::BINARY)
+    output = String.new(encoding: Encoding::ASCII)
     template = Liquid::Template.parse("ascii text")
     exc = assert_raises(Encoding::CompatibilityError) do
       template.render!({}, output: output)
     end
-    assert_equal("non-UTF8 encoded output (ASCII-8BIT) not supported", exc.message)
+    assert_equal("non-UTF8 encoded output (US-ASCII) not supported", exc.message)
   end
 
   def test_write_unicode_characters


### PR DESCRIPTION
I noticed that I accidentally left the encoding in the encoding error message hard coded in https://github.com/Shopify/liquid-c/pull/66, so passed the string into the raise method and used it in the error message