### PR TITLE
Fix infinite loop in the buffer when capacity is set to 0

### DIFF
--- a/ext/liquid_c/c_buffer.c
+++ b/ext/liquid_c/c_buffer.c
@@ -5,7 +5,7 @@ static void c_buffer_reserve(c_buffer_t *buffer, size_t required_capacity)
     if (buffer->capacity >= required_capacity)
         return;
 
-    size_t new_capacity = buffer->capacity;
+    size_t new_capacity = buffer->capacity + 1;
     do {
         new_capacity *= 2;
     } while (new_capacity < required_capacity);


### PR DESCRIPTION
If we try to allocate a buffer with capacity set to 0, resizing it will cause an infinite loop because `new_capacity *= 2;` will always be `0`.