### PR TITLE
Extract a vm_assembler_t struct from block_body_t

### DIFF
--- a/ext/liquid_c/block.h
+++ b/ext/liquid_c/block.h
@@ -1,11 +1,10 @@
 #if !defined(LIQUID_BLOCK_H)
 #define LIQUID_BLOCK_H
 
-#include "c_buffer.h"
+#include "vm_assembler.h"
 
 typedef struct block_body {
-    c_buffer_t instructions;
-    c_buffer_t constants;
+    vm_assembler_t code;
     VALUE source; // hold a reference to the ruby object that OP_WRITE_RAW points to
     bool parsing; // use to prevent rendering when parsing is incomplete
     bool blank;

--- a/ext/liquid_c/vm.c
+++ b/ext/liquid_c/vm.c
@@ -15,8 +15,8 @@ void liquid_vm_render(block_body_t *body, VALUE context, VALUE output)
 
     resource_limits_increment_render_score(resource_limits, body->render_score);
 
-    const size_t *const_ptr = (const size_t *)body->constants.data;
-    const uint8_t *ip = body->instructions.data;
+    const size_t *const_ptr = (const size_t *)body->code.constants.data;
+    const uint8_t *ip = body->code.instructions.data;
     VALUE interrupts = rb_ivar_get(context, id_ivar_interrupts);
     Check_Type(interrupts, T_ARRAY);
 

--- a/ext/liquid_c/vm.h
+++ b/ext/liquid_c/vm.h
@@ -4,12 +4,6 @@
 #include <ruby.h>
 #include "block.h"
 
-enum opcode {
-    OP_LEAVE = 0,
-    OP_WRITE_RAW = 1,
-    OP_WRITE_NODE = 2,
-};
-
 void init_liquid_vm();
 void liquid_vm_render(block_body_t *block, VALUE context, VALUE output);
 

--- a/ext/liquid_c/vm_assembler.c
+++ b/ext/liquid_c/vm_assembler.c
@@ -1,0 +1,49 @@
+#include "vm_assembler.h"
+
+void vm_assembler_init(vm_assembler_t *code)
+{
+    code->instructions = c_buffer_allocate(8);
+    code->constants = c_buffer_allocate(8 * sizeof(VALUE));
+}
+
+void vm_assembler_free(vm_assembler_t *code)
+{
+    c_buffer_free(&code->instructions);
+    c_buffer_free(&code->constants);
+}
+
+void vm_assembler_gc_mark(vm_assembler_t *code)
+{
+    size_t *const_ptr = (size_t *)code->constants.data;
+    const uint8_t *ip = code->instructions.data;
+    // Don't rely on a terminating OP_LEAVE instruction
+    // since this could be called in the middle of parsing
+    const uint8_t *end_ip = ip + code->instructions.size;
+    while (ip < end_ip) {
+        switch (*ip++) {
+            case OP_LEAVE:
+                break;
+            case OP_WRITE_RAW:
+                const_ptr += 2;
+                break;
+            case OP_WRITE_NODE:
+                rb_gc_mark(*const_ptr++);
+                break;
+            default:
+                rb_bug("invalid opcode: %u", ip[-1]);
+        }
+    }
+}
+
+void vm_assembler_add_write_raw(vm_assembler_t *code, const char *string, size_t size)
+{
+    vm_assembler_write_opcode(code, OP_WRITE_RAW);
+    size_t slice[2] = { (size_t)string, size };
+    c_buffer_write(&code->constants, &slice, sizeof(slice));
+}
+
+void vm_assembler_add_write_node(vm_assembler_t *code, VALUE node)
+{
+    vm_assembler_write_opcode(code, OP_WRITE_NODE);
+    vm_assembler_write_ruby_constant(code, node);
+}

--- a/ext/liquid_c/vm_assembler.h
+++ b/ext/liquid_c/vm_assembler.h
@@ -1,0 +1,48 @@
+#ifndef VM_ASSEMBLER_H
+#define VM_ASSEMBLER_H
+
+#include "c_buffer.h"
+
+enum opcode {
+    OP_LEAVE = 0,
+    OP_WRITE_RAW = 1,
+    OP_WRITE_NODE = 2,
+};
+
+typedef struct vm_assembler {
+    c_buffer_t instructions;
+    c_buffer_t constants;
+} vm_assembler_t;
+
+void vm_assembler_init(vm_assembler_t *code);
+void vm_assembler_free(vm_assembler_t *code);
+void vm_assembler_gc_mark(vm_assembler_t *code);
+void vm_assembler_add_write_raw(vm_assembler_t *code, const char *string, size_t size);
+void vm_assembler_add_write_node(vm_assembler_t *code, VALUE node);
+
+static inline size_t vm_assembler_alloc_memsize(const vm_assembler_t *code)
+{
+    return code->instructions.capacity + code->constants.capacity;
+}
+
+static inline void vm_assembler_write_opcode(vm_assembler_t *code, enum opcode op)
+{
+    c_buffer_write_byte(&code->instructions, op);
+}
+
+static inline void vm_assembler_write_ruby_constant(vm_assembler_t *code, VALUE constant)
+{
+    c_buffer_write(&code->constants, &constant, sizeof(VALUE));
+}
+
+static inline void vm_assembler_add_leave(vm_assembler_t *code)
+{
+    vm_assembler_write_opcode(code, OP_LEAVE);
+}
+
+static inline void vm_assembler_remove_leave(vm_assembler_t *code)
+{
+    code->instructions.size -= 1;
+}
+
+#endif


### PR DESCRIPTION
Extracted from https://github.com/Shopify/liquid-c/pull/59

## Problem

In https://github.com/Shopify/liquid-c/pull/60 I am introducing a Liquid::C::Expression, which contains a subset fo the VM code that a Liquid::C::BlockBody can contain, since an expression can be parsed and used outside of a block body.  In order to avoid duplication between these objects, we should have some common code to abstract the building of VM code.

## Solution

I've moved the VM instructions and constants out of block_body_t into a vm_assembler_t struct, since we will want to embed the VM code in Liquid::C::Expression.