### PR TITLE
Refactor c_buffer to make it suitable to re-use for a stack

### DIFF
--- a/ext/liquid_c/block.c
+++ b/ext/liquid_c/block.c
@@ -309,7 +309,7 @@ static VALUE block_body_nodelist(VALUE self)
     VALUE nodelist = rb_attr_get(self, intern_ivar_nodelist);
     if (nodelist != Qnil)
         return nodelist;
-    nodelist = rb_ary_new_capa(body->code.instructions.size / sizeof(VALUE));
+    nodelist = rb_ary_new_capa(body->render_score);
 
     const size_t *const_ptr = (size_t *)body->code.constants.data;
     const uint8_t *ip = body->code.instructions.data;

--- a/ext/liquid_c/c_buffer.c
+++ b/ext/liquid_c/c_buffer.c
@@ -6,6 +6,8 @@ static void c_buffer_expand_for_write(c_buffer_t *buffer, size_t write_size)
     size_t size = c_buffer_size(buffer);
     size_t required_capacity = size + write_size;
 
+    if (capacity < 1)
+        capacity = 1;
     do {
         capacity *= 2;
     } while (capacity < required_capacity);
@@ -14,7 +16,7 @@ static void c_buffer_expand_for_write(c_buffer_t *buffer, size_t write_size)
     buffer->capacity_end = buffer->data + capacity;
 }
 
-static void c_buffer_reserve_for_write(c_buffer_t *buffer, size_t write_size)
+void c_buffer_reserve_for_write(c_buffer_t *buffer, size_t write_size)
 {
     uint8_t *write_end = buffer->data_end + write_size;
     if (write_end > buffer->capacity_end) {

--- a/ext/liquid_c/c_buffer.c
+++ b/ext/liquid_c/c_buffer.c
@@ -1,21 +1,30 @@
 #include "c_buffer.h"
 
-static void c_buffer_reserve(c_buffer_t *buffer, size_t required_capacity)
+static void c_buffer_expand_for_write(c_buffer_t *buffer, size_t write_size)
 {
-    if (buffer->capacity >= required_capacity)
-        return;
+    size_t capacity = c_buffer_capacity(buffer);
+    size_t size = c_buffer_size(buffer);
+    size_t required_capacity = size + write_size;
 
-    size_t new_capacity = buffer->capacity;
     do {
-        new_capacity *= 2;
-    } while (new_capacity < required_capacity);
-    buffer->data = xrealloc(buffer->data, new_capacity);
-    buffer->capacity = new_capacity;
+        capacity *= 2;
+    } while (capacity < required_capacity);
+    buffer->data = xrealloc(buffer->data, capacity);
+    buffer->data_end = buffer->data + size;
+    buffer->capacity_end = buffer->data + capacity;
+}
+
+static void c_buffer_reserve_for_write(c_buffer_t *buffer, size_t write_size)
+{
+    uint8_t *write_end = buffer->data_end + write_size;
+    if (write_end > buffer->capacity_end) {
+        c_buffer_expand_for_write(buffer, write_size);
+    }
 }
 
 void c_buffer_write(c_buffer_t *buffer, void *write_data, size_t write_size)
 {
-    c_buffer_reserve(buffer, buffer->size + write_size);
-    memcpy(buffer->data + buffer->size, write_data, write_size);
-    buffer->size += write_size;
+    c_buffer_reserve_for_write(buffer, write_size);
+    memcpy(buffer->data_end, write_data, write_size);
+    buffer->data_end += write_size;
 }

--- a/ext/liquid_c/c_buffer.h
+++ b/ext/liquid_c/c_buffer.h
@@ -9,6 +9,11 @@ typedef struct c_buffer {
     uint8_t *capacity_end;
 } c_buffer_t;
 
+inline c_buffer_t c_buffer_init()
+{
+    return (c_buffer_t) { NULL, NULL, NULL };
+}
+
 inline c_buffer_t c_buffer_allocate(size_t capacity)
 {
     uint8_t *data = xmalloc(capacity);
@@ -30,6 +35,7 @@ inline size_t c_buffer_capacity(const c_buffer_t *buffer)
     return buffer->capacity_end - buffer->data;
 }
 
+void c_buffer_reserve_for_write(c_buffer_t *buffer, size_t write_size);
 void c_buffer_write(c_buffer_t *buffer, void *data, size_t size);
 
 inline void c_buffer_write_byte(c_buffer_t *buffer, uint8_t byte) {

--- a/ext/liquid_c/c_buffer.h
+++ b/ext/liquid_c/c_buffer.h
@@ -5,18 +5,29 @@
 
 typedef struct c_buffer {
     uint8_t *data;
-    size_t size;
-    size_t capacity;
+    uint8_t *data_end;
+    uint8_t *capacity_end;
 } c_buffer_t;
 
 inline c_buffer_t c_buffer_allocate(size_t capacity)
 {
-    return (c_buffer_t) { xmalloc(capacity), 0, capacity };
+    uint8_t *data = xmalloc(capacity);
+    return (c_buffer_t) { data, data, data + capacity };
 }
 
 inline void c_buffer_free(c_buffer_t *buffer)
 {
     xfree(buffer->data);
+}
+
+inline size_t c_buffer_size(const c_buffer_t *buffer)
+{
+    return buffer->data_end - buffer->data;
+}
+
+inline size_t c_buffer_capacity(const c_buffer_t *buffer)
+{
+    return buffer->capacity_end - buffer->data;
 }
 
 void c_buffer_write(c_buffer_t *buffer, void *data, size_t size);

--- a/ext/liquid_c/vm_assembler.c
+++ b/ext/liquid_c/vm_assembler.c
@@ -18,7 +18,7 @@ void vm_assembler_gc_mark(vm_assembler_t *code)
     const uint8_t *ip = code->instructions.data;
     // Don't rely on a terminating OP_LEAVE instruction
     // since this could be called in the middle of parsing
-    const uint8_t *end_ip = ip + code->instructions.size;
+    const uint8_t *end_ip = code->instructions.data_end;
     while (ip < end_ip) {
         switch (*ip++) {
             case OP_LEAVE:

--- a/ext/liquid_c/vm_assembler.h
+++ b/ext/liquid_c/vm_assembler.h
@@ -22,7 +22,7 @@ void vm_assembler_add_write_node(vm_assembler_t *code, VALUE node);
 
 static inline size_t vm_assembler_alloc_memsize(const vm_assembler_t *code)
 {
-    return code->instructions.capacity + code->constants.capacity;
+    return c_buffer_capacity(&code->instructions) + c_buffer_capacity(&code->constants);
 }
 
 static inline void vm_assembler_write_opcode(vm_assembler_t *code, enum opcode op)
@@ -42,7 +42,7 @@ static inline void vm_assembler_add_leave(vm_assembler_t *code)
 
 static inline void vm_assembler_remove_leave(vm_assembler_t *code)
 {
-    code->instructions.size -= 1;
+    code->instructions.data_end--;
 }
 
 #endif


### PR DESCRIPTION
Extracted from https://github.com/Shopify/liquid-c/pull/59

> * I changed the c_buffer struct to store pointers for the end of the data and capacity, instead of storing the sizes and capacity directly. This is because we are mostly getting and updating the data end pointer, which is especially true in order to use this for the VM stack where we reserve space for the block and don't have to check the capacity for each write/push.
> * I've also added support to c_buffer to be initialized with size 0 (without an allocation) which is the one case where we can't just double the capacity until we have the requested extra capacity.
