### PR TITLE
Implement Liquid::Raw#parse

### DIFF
--- a/ext/liquid_c/liquid.c
+++ b/ext/liquid_c/liquid.c
@@ -3,6 +3,7 @@
 #include "variable.h"
 #include "lexer.h"
 #include "parser.h"
+#include "raw.h"
 #include "resource_limits.h"
 #include "block.h"
 #include "context.h"
@@ -46,6 +47,7 @@ void Init_liquid_c(void)
 
     init_liquid_tokenizer();
     init_liquid_parser();
+    init_liquid_raw();
     init_liquid_resource_limits();
     init_liquid_variable();
     init_liquid_block();

--- a/ext/liquid_c/raw.c
+++ b/ext/liquid_c/raw.c
@@ -1,0 +1,114 @@
+#include "liquid.h"
+#include "raw.h"
+#include "stringutil.h"
+#include "tokenizer.h"
+
+VALUE cLiquidRaw;
+static VALUE id_parse_context, id_locale, id_translate, id_block_name, id_block_delimiter, id_ivar_body;
+
+__attribute__((noreturn)) static void raise_translated_syntax_error(VALUE self, const char *key, VALUE args)
+{
+    VALUE key_str = rb_str_new_cstr(key);
+    VALUE msg = rb_funcall(rb_funcall(rb_funcall(self, id_parse_context, 0), id_locale, 0), id_translate, 2, key_str, args);
+    rb_raise(cLiquidSyntaxError, "%.*s", (int)RSTRING_LEN(msg), RSTRING_PTR(msg));
+}
+
+struct full_token_possibly_invalid_t {
+    const char *body_start;
+    long body_len;
+    const char *delimiter_start;
+    long delimiter_len;
+};
+
+static bool match_full_token_possibly_invalid(token_t *token, struct full_token_possibly_invalid_t *match)
+{
+    const char *str = token->str_full;
+    long len = token->len_full;
+
+    match->body_start = str;
+    match->body_len = 0;
+    match->delimiter_start = NULL;
+    match->delimiter_len = 0;
+
+    if (len < 5) return false; // Must be at least 5 characters: \{%\w%\}
+    if (str[len - 1] != '}' || str[len - 2] != '%') return false;
+
+    const char *curr_delimiter_start;
+    long curr_delimiter_len = 0;
+
+    for (long i = len - 3; i >= 0; i--) {
+        char c = str[i];
+
+        if (is_word(c)) {
+            curr_delimiter_start = str + i;
+            curr_delimiter_len++;
+        } else {
+            if (curr_delimiter_len > 0) {
+                match->delimiter_start = curr_delimiter_start;
+                match->delimiter_len = curr_delimiter_len;
+            }
+            curr_delimiter_start = NULL;
+            curr_delimiter_len = 0;
+        }
+
+        if (c == '%' && match->delimiter_len > 0 &&
+                i - 1 >= 0 && str[i - 1] == '{') {
+            match->body_len = i - 1;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static VALUE raw_parse_method(VALUE self, VALUE tokens)
+{
+    c_buffer_t body = c_buffer_allocate(0);
+
+    tokenizer_t *tokenizer;
+    Tokenizer_Get_Struct(tokens, tokenizer);
+
+    token_t token;
+    struct full_token_possibly_invalid_t match;
+
+    VALUE block_delimiter = rb_funcall(self, id_block_delimiter, 0);
+    Check_Type(block_delimiter, T_STRING);
+    char *block_delimiter_str = RSTRING_PTR(block_delimiter);
+    long block_delimiter_len = RSTRING_LEN(block_delimiter);
+
+    while (true) {
+        tokenizer_next(tokenizer, &token);
+
+        if (!token.type) break;
+
+        if (match_full_token_possibly_invalid(&token, &match)
+                && match.delimiter_len == block_delimiter_len
+                && strncmp(match.delimiter_start, block_delimiter_str, block_delimiter_len) == 0) {
+            c_buffer_write(&body, (void *)match.body_start, match.body_len);
+            VALUE body_str = rb_str_new((char *)body.data,  c_buffer_size(&body));
+            rb_ivar_set(self, id_ivar_body, body_str);
+            return Qnil;
+        }
+
+        c_buffer_write(&body, (char *)token.str_full, token.len_full);
+    }
+
+    VALUE hash = rb_hash_new();
+    rb_hash_aset(hash, id_block_name, rb_funcall(self, id_block_name, 0));
+    raise_translated_syntax_error(self, "errors.syntax.tag_never_closed", hash);
+}
+
+void init_liquid_raw()
+{
+    id_parse_context = rb_intern("parse_context");
+    id_locale = rb_intern("locale");
+    id_translate = rb_intern("t");
+    id_block_name = rb_intern("block_name");
+    id_block_delimiter = rb_intern("block_delimiter");
+    id_ivar_body = rb_intern("@body");
+
+    cLiquidRaw = rb_const_get(mLiquid, rb_intern("Raw"));
+    rb_global_variable(&cLiquidRaw);
+
+    rb_define_method(cLiquidRaw, "c_parse", raw_parse_method, 1);
+}

--- a/ext/liquid_c/raw.h
+++ b/ext/liquid_c/raw.h
@@ -1,0 +1,18 @@
+#ifndef LIQUID_RAW_H
+#define LIQUID_RAW_H
+
+#include "c_buffer.h"
+
+typedef struct raw {
+    VALUE tag_name;
+    VALUE parse_context;
+    c_buffer_t body;
+} raw_t;
+
+extern VALUE cLiquidRaw;
+extern const rb_data_type_t raw_data_type;
+#define Raw_Get_Struct(obj, sval) TypedData_Get_Struct(obj, raw_t, &raw_data_type, sval)
+
+void init_liquid_raw();
+
+#endif

--- a/ext/liquid_c/raw.h
+++ b/ext/liquid_c/raw.h
@@ -1,18 +1,6 @@
 #ifndef LIQUID_RAW_H
 #define LIQUID_RAW_H
 
-#include "c_buffer.h"
-
-typedef struct raw {
-    VALUE tag_name;
-    VALUE parse_context;
-    c_buffer_t body;
-} raw_t;
-
-extern VALUE cLiquidRaw;
-extern const rb_data_type_t raw_data_type;
-#define Raw_Get_Struct(obj, sval) TypedData_Get_Struct(obj, raw_t, &raw_data_type, sval)
-
 void init_liquid_raw();
 
 #endif

--- a/ext/liquid_c/stringutil.h
+++ b/ext/liquid_c/stringutil.h
@@ -30,9 +30,9 @@ inline static int not_newline(int c)
     return c != '\n';
 }
 
-inline static bool is_word(char c)
+inline static bool is_word_char(char c)
 {
-    return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || ('0' <= c && c <= '9') || c == '_';
+    return ISALNUM(c) || c == '_';
 }
 
 #endif

--- a/ext/liquid_c/stringutil.h
+++ b/ext/liquid_c/stringutil.h
@@ -30,5 +30,10 @@ inline static int not_newline(int c)
     return c != '\n';
 }
 
+inline static bool is_word(char c)
+{
+    return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || ('0' <= c && c <= '9') || c == '_';
+}
+
 #endif
 

--- a/lib/liquid/c.rb
+++ b/lib/liquid/c.rb
@@ -20,6 +20,10 @@ Liquid::Tokenizer.class_eval do
   end
 end
 
+Liquid::Raw.class_eval do
+  alias_method :ruby_parse, :parse
+end
+
 Liquid::ParseContext.class_eval do
   alias_method :ruby_new_block_body, :new_block_body
 
@@ -155,10 +159,12 @@ module Liquid
         if value
           Liquid::Context.send(:alias_method, :evaluate, :c_evaluate)
           Liquid::Context.send(:alias_method, :find_variable, :c_find_variable_kwarg)
+          Liquid::Raw.send(:alias_method, :parse, :c_parse)
           Liquid::VariableLookup.send(:alias_method, :evaluate, :c_evaluate)
         else
           Liquid::Context.send(:alias_method, :evaluate, :ruby_evaluate)
           Liquid::Context.send(:alias_method, :find_variable, :ruby_find_variable)
+          Liquid::Raw.send(:alias_method, :parse, :ruby_parse)
           Liquid::VariableLookup.send(:alias_method, :evaluate, :ruby_evaluate)
         end
       end


### PR DESCRIPTION
Implement `Liquid::Raw#parse`.

The function `match_full_token_possibly_invalid` emulates matching the `FullTokenPossiblyInvalid = /\A(.*)#{TagStart}\s*(\w+)\s*(.*)?#{TagEnd}\z/om` regex.

# Benchmark

For the benchmark, I wrapped every `theme.liquid` in a `raw` tag and ran the benchmark.

Master:

```
              parse:    175.223  (± 9.7%) i/s -      1.746k in  10.078290s
             render:    250.375  (± 8.4%) i/s -      2.496k in  10.042677s
     parse & render:     96.516  (± 7.3%) i/s -    960.000  in  10.009864s
```

This branch:

```
              parse:    280.836  (± 9.3%) i/s -      2.793k in  10.040895s
             render:    236.161  (±12.3%) i/s -      2.340k in  10.076232s
     parse & render:    120.075  (± 9.2%) i/s -      1.199k in  10.070105s
```

In this (very) synthetic benchmark, we see a 60% increase in performance during parsing. 
