### PR TITLE
Add liquid_vm_next_instruction to reduce duplication

### DIFF
--- a/ext/liquid_c/vm.c
+++ b/ext/liquid_c/vm.c
@@ -8,6 +8,28 @@ ID id_render_node;
 ID id_ivar_interrupts;
 ID id_ivar_resource_limits;
 
+void liquid_vm_next_instruction(const uint8_t **ip_ptr, const size_t **const_ptr_ptr)
+{
+    const uint8_t *ip = *ip_ptr;
+
+    switch (*ip++) {
+        case OP_LEAVE:
+            break;
+
+        case OP_WRITE_NODE:
+            (*const_ptr_ptr)++;
+            break;
+
+        case OP_WRITE_RAW:
+            (*const_ptr_ptr) += 2;
+            break;
+
+        default:
+            rb_bug("invalid opcode: %u", ip[-1]);
+    }
+    *ip_ptr = ip;
+}
+
 void liquid_vm_render(block_body_t *body, VALUE context, VALUE output)
 {
     resource_limits_t *resource_limits;

--- a/ext/liquid_c/vm.h
+++ b/ext/liquid_c/vm.h
@@ -6,5 +6,6 @@
 
 void init_liquid_vm();
 void liquid_vm_render(block_body_t *block, VALUE context, VALUE output);
+void liquid_vm_next_instruction(const uint8_t **ip_ptr, const size_t **const_ptr_ptr);
 
 #endif


### PR DESCRIPTION
This is another refactor I extracted from https://github.com/Shopify/liquid-c/pull/59

> I've added a liquid_vm_next_instruction function to reduce duplication for code iterating instructions by using it for both Liquid::C::BlockBody#remove_blank_strings and Liquid::C::BlockBody#nodelist. This way I can further leverage it for variable error handling.