### PR TITLE
No -Werror on Linux on Ruby 2.6 or earlier

### DIFF
--- a/ext/liquid_c/extconf.rb
+++ b/ext/liquid_c/extconf.rb
@@ -1,5 +1,8 @@
 require 'mkmf'
-$CFLAGS << ' -std=c99 -Wall -Werror -Wextra -Wno-unused-parameter -Wno-missing-field-initializers'
+$CFLAGS << ' -std=c99 -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers'
+if RbConfig::CONFIG['host_os'] !~ /linux/ || Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7")
+  $CFLAGS << ' -Werror'
+end
 compiler = RbConfig::MAKEFILE_CONFIG['CC']
 if ENV['DEBUG'] == 'true' && compiler =~ /gcc|g\+\+/
   $CFLAGS << ' -fbounds-check'


### PR DESCRIPTION
In Ruby 2.6 and earlier, the Ruby headers did not have `struct timespec` defined, which fails to compile (definition was added in [this commit](https://github.com/ruby/ruby/commit/bf53d6c7d19f877c821901b3288d7f80955ffbb7#diff-74bc68e685da4c1726b1fb30f863b617R24)). This PR removes `-Werror` when building on Linux for Ruby 2.6 or eariler.

Note that this wasn't the first time we've seen this issue. See Shopify/rotoscope#71 and Shopify/bootsnap#15.

Error message:

```sh
> docker run -it --rm ruby:2.6.6 /bin/bash -c "git clone git://github.com/shopify/liquid-c && cd liquid-c && bundle && bundle exec rake"

compiling ../../../../ext/liquid_c/vm.c
In file included from /usr/local/include/ruby-2.6.0/ruby/ruby.h:2111,
                 from /usr/local/include/ruby-2.6.0/ruby.h:33,
                 from ../../../../ext/liquid_c/liquid.h:4,
                 from ../../../../ext/liquid_c/vm.c:3:
/usr/local/include/ruby-2.6.0/ruby/intern.h:928:29: error: ‘struct timespec’ declared inside parameter list will not be visible outside of this definition or declaration [-Werror]
 void rb_timespec_now(struct timespec *);
                             ^~~~~~~~
/usr/local/include/ruby-2.6.0/ruby/intern.h:931:41: error: ‘struct timespec’ declared inside parameter list will not be visible outside of this definition or declaration [-Werror]
 VALUE rb_time_timespec_new(const struct timespec *, int);
                                         ^~~~~~~~
cc1: error: unrecognized command line option ‘-Wno-self-assign’ [-Werror]
cc1: error: unrecognized command line option ‘-Wno-parentheses-equality’ [-Werror]
cc1: error: unrecognized command line option ‘-Wno-constant-logical-operand’ [-Werror]
cc1: all warnings being treated as errors
```