### PR TITLE
Allow UTF-8 compatible template source to be used again

### DIFF
--- a/lib/liquid/c.rb
+++ b/lib/liquid/c.rb
@@ -13,7 +13,8 @@ end
 Liquid::Tokenizer.class_eval do
   def self.new(source, line_numbers = false, line_number: nil, for_liquid_tag: false)
     if Liquid::C.enabled
-      Liquid::C::Tokenizer.new(source.to_s, line_number || (line_numbers ? 1 : 0), for_liquid_tag)
+      source = source.to_s.encode(Encoding::UTF_8)
+      Liquid::C::Tokenizer.new(source, line_number || (line_numbers ? 1 : 0), for_liquid_tag)
     else
       super
     end

--- a/test/unit/tokenizer_test.rb
+++ b/test/unit/tokenizer_test.rb
@@ -37,7 +37,7 @@ class TokenizerTest < Minitest::Test
     assert_equal ["funk", "so | brother"], tokenize(source, for_liquid_tag: true, trimmed: true)
   end
 
-  def test_utf8_encoded_template
+  def test_utf8_encoded_source
     source = 'auswählen'
     assert_equal Encoding::UTF_8, source.encoding
     output = tokenize(source)
@@ -45,8 +45,17 @@ class TokenizerTest < Minitest::Test
     assert_equal [source], output
   end
 
-  def test_non_utf8_encoded_template
-    source = String.new('ascii text', encoding: Encoding::BINARY)
+  def test_utf8_compatible_source
+    source = String.new('ascii', encoding: Encoding::ASCII)
+    tokenizer = Liquid::Tokenizer.new(source)
+    output = tokenizer.shift
+    assert_equal Encoding::UTF_8, output.encoding
+    assert_equal source, output
+    assert_nil(tokenizer.shift)
+  end
+
+  def test_non_utf8_compatible_source
+    source = 'üñicode'.force_encoding(Encoding::BINARY)
     exc = assert_raises(Encoding::CompatibilityError) do
       Liquid::C::Tokenizer.new(source, 1, false)
     end


### PR DESCRIPTION
## Problem

https://github.com/Shopify/liquid-c/pull/66 ended up being more of a breaking change than I expected on Shopify Core, resulting in a lot of test failures for non-UTF-encoded strings passed to various uses of Liquid::Template.parse.

One of the most annoying and concerning cases is when `to_s` is called on a non-string, which can convert it to a binary encoded string.  E.g. `nil.to_s.encoding` returns `Encoding::BINARY`.

## Solution

Use `.encode(Encoding::UTF_8)` on the template source string in the Liquid::Tokenizer.new patch, to allow non-UTF-8 strings.  This will still ensure the string is UTF-8 encoded for the liquid VM code, while also being more convenient for users of the library.