### PR TITLE
Implement OP_RENDER_VARIABLE_RESCUE on the instructions buffer

### DIFF
--- a/ext/liquid_c/vm.c
+++ b/ext/liquid_c/vm.c
@@ -194,7 +194,7 @@ typedef struct vm_render_until_error_args {
     vm_t *vm;
     const uint8_t *ip; // use for initial address and to save an address for rescuing
     const size_t *const_ptr;
-    uint8_t node_line_number[3];
+    const uint8_t *node_line_number;
     VALUE context;
     VALUE output;
 } vm_render_until_error_args_t;
@@ -273,7 +273,7 @@ static VALUE vm_render_until_error(VALUE uncast_args)
                 break;
             case OP_RENDER_VARIABLE_RESCUE:
                 // Save state used by vm_render_rescue to rescue from a variable rendering exception
-                memcpy(&args->node_line_number, ip, sizeof(args->node_line_number));
+                args->node_line_number = ip;
                 // vm_render_rescue will iterate from this instruction to the instruction
                 // following OP_POP_WRITE_VARIABLE to resume rendering from
                 ip += 3;
@@ -340,7 +340,7 @@ typedef struct vm_render_rescue_args {
     size_t old_stack_byte_size;
 } vm_render_rescue_args_t;
 
-static inline unsigned int decode_node_line_number(uint8_t *node_line_number)
+static inline unsigned int decode_node_line_number(const uint8_t *node_line_number)
 {
     return (node_line_number[0] << 16) | (node_line_number[1] << 8) | node_line_number[2];
 }
@@ -375,8 +375,13 @@ static VALUE vm_render_rescue(VALUE uncast_args, VALUE exception)
         vm->invoking_filter = false;
     }
 
-    unsigned int node_line_number = decode_node_line_number(render_args->node_line_number);
-    VALUE line_number = node_line_number == 0 ? Qnil : UINT2NUM(node_line_number);
+    VALUE line_number = Qnil;
+    if (render_args->node_line_number) {
+        unsigned int node_line_number = decode_node_line_number(render_args->node_line_number);
+        if (node_line_number != 0) {
+            line_number = UINT2NUM(node_line_number);
+        }
+    }
 
     rb_funcall(cLiquidBlockBody, rb_intern("c_rescue_render_node"), 5,
         render_args->context, render_args->output, line_number, exception, blank_tag);

--- a/ext/liquid_c/vm.c
+++ b/ext/liquid_c/vm.c
@@ -273,9 +273,10 @@ static VALUE vm_render_until_error(VALUE uncast_args)
                 break;
             case OP_RENDER_VARIABLE_RESCUE:
                 // Save state used by vm_render_rescue to rescue from a variable rendering exception
-                args->node_line_number = (unsigned int)*const_ptr++;
+                args->node_line_number = (ip[0] << 16) | (ip[1] << 8) | ip[2];
                 // vm_render_rescue will iterate from this instruction to the instruction
                 // following OP_POP_WRITE_VARIABLE to resume rendering from
+                ip += 3;
                 args->ip = ip;
                 args->const_ptr = const_ptr;
                 break;
@@ -312,8 +313,11 @@ void liquid_vm_next_instruction(const uint8_t **ip_ptr, const size_t **const_ptr
         case OP_WRITE_NODE:
         case OP_PUSH_CONST:
         case OP_PUSH_EVAL_EXPR:
-        case OP_RENDER_VARIABLE_RESCUE:
             (*const_ptr_ptr)++;
+            break;
+
+        case OP_RENDER_VARIABLE_RESCUE:
+            ip += 3;
             break;
 
         case OP_FILTER:

--- a/ext/liquid_c/vm_assembler.c
+++ b/ext/liquid_c/vm_assembler.c
@@ -32,7 +32,7 @@ void vm_assembler_gc_mark(vm_assembler_t *code)
                 break;
 
             case OP_RENDER_VARIABLE_RESCUE:
-                const_ptr++;
+                ip += 3;
                 break;
 
             case OP_WRITE_RAW:

--- a/ext/liquid_c/vm_assembler.h
+++ b/ext/liquid_c/vm_assembler.h
@@ -102,10 +102,6 @@ static inline void vm_assembler_add_filter(vm_assembler_t *code, VALUE filter_na
 
 static inline void vm_assembler_add_render_variable_rescue(vm_assembler_t *code, size_t node_line_number)
 {
-    if (RB_UNLIKELY(node_line_number >= (1 << 24))) {
-        rb_enc_raise(utf8_encoding, rb_eRuntimeError, "Line number %ld is too large", node_line_number);
-    }
-
     uint8_t instructions[4] = { OP_RENDER_VARIABLE_RESCUE, node_line_number >> 16, node_line_number >> 8, node_line_number };
     c_buffer_write(&code->instructions, &instructions, sizeof(instructions));
 }

--- a/ext/liquid_c/vm_assembler.h
+++ b/ext/liquid_c/vm_assembler.h
@@ -101,8 +101,10 @@ static inline void vm_assembler_add_filter(vm_assembler_t *code, VALUE filter_na
 
 static inline void vm_assembler_add_render_variable_rescue(vm_assembler_t *code, size_t node_line_number)
 {
-    c_buffer_write(&code->constants, &node_line_number, sizeof(size_t));
-    vm_assembler_write_opcode(code, OP_RENDER_VARIABLE_RESCUE);
+    assert(node_line_number < (1 << 24));
+
+    uint8_t instructions[4] = { OP_RENDER_VARIABLE_RESCUE, node_line_number >> 16, node_line_number >> 8, node_line_number };
+    c_buffer_write(&code->instructions, &instructions, sizeof(instructions));
 }
 
 #endif

--- a/ext/liquid_c/vm_assembler.h
+++ b/ext/liquid_c/vm_assembler.h
@@ -2,6 +2,7 @@
 #define VM_ASSEMBLER_H
 
 #include <assert.h>
+#include "liquid.h"
 #include "c_buffer.h"
 
 enum opcode {
@@ -101,7 +102,9 @@ static inline void vm_assembler_add_filter(vm_assembler_t *code, VALUE filter_na
 
 static inline void vm_assembler_add_render_variable_rescue(vm_assembler_t *code, size_t node_line_number)
 {
-    assert(node_line_number < (1 << 24));
+    if (RB_UNLIKELY(node_line_number >= (1 << 24))) {
+        rb_enc_raise(utf8_encoding, rb_eRuntimeError, "Line number %ld is too large", node_line_number);
+    }
 
     uint8_t instructions[4] = { OP_RENDER_VARIABLE_RESCUE, node_line_number >> 16, node_line_number >> 8, node_line_number };
     c_buffer_write(&code->instructions, &instructions, sizeof(instructions));

--- a/test/unit/variable_test.rb
+++ b/test/unit/variable_test.rb
@@ -169,6 +169,14 @@ class VariableTest < Minitest::Test
     assert_equal 'before (Liquid error: concat filter requires an array argument) after', output
   end
 
+  def test_line_number_too_large
+    err = assert_raises(RuntimeError) do
+      Liquid::Template.parse("\n" * (2 ** 24) + "{{ foo }}", line_numbers: true)
+    end
+
+    assert_equal "Line number 16777217 is too large", err.message
+  end
+
   private
 
   def create_variable(markup, options={})

--- a/test/unit/variable_test.rb
+++ b/test/unit/variable_test.rb
@@ -169,14 +169,6 @@ class VariableTest < Minitest::Test
     assert_equal 'before (Liquid error: concat filter requires an array argument) after', output
   end
 
-  def test_line_number_too_large
-    err = assert_raises(RuntimeError) do
-      Liquid::Template.parse("\n" * (2 ** 24) + "{{ foo }}", line_numbers: true)
-    end
-
-    assert_equal "Line number 16777217 is too large", err.message
-  end
-
   private
 
   def create_variable(markup, options={})


### PR DESCRIPTION
This implements storing the line number of OP_RENDER_VARIABLE_RESCUE instruction on the instructions buffer rather than the constants buffer. We only need to support line number of up to 24 bytes so it's stored as 3 x 8 byte values. 

See #77.
