### PR TITLE
Require source code to be at most 16MiB

### DIFF
--- a/ext/liquid_c/tokenizer.c
+++ b/ext/liquid_c/tokenizer.c
@@ -47,6 +47,12 @@ static VALUE tokenizer_initialize_method(VALUE self, VALUE source, VALUE start_l
     Check_Type(source, T_STRING);
     check_utf8_encoding(source, "source");
 
+#define MAX_SOURCE_CODE_BYTES ((1 << 24) - 1)
+    if (RSTRING_LEN(source) > MAX_SOURCE_CODE_BYTES) {
+        rb_enc_raise(utf8_encoding, rb_eArgError, "Source too large, max %d bytes", MAX_SOURCE_CODE_BYTES);
+    }
+#undef MAX_SOURCE_CODE_BYTES
+
     Tokenizer_Get_Struct(self, tokenizer);
     source = rb_str_dup_frozen(source);
     tokenizer->source = source;

--- a/test/unit/tokenizer_test.rb
+++ b/test/unit/tokenizer_test.rb
@@ -62,6 +62,14 @@ class TokenizerTest < Minitest::Test
     assert_equal("non-UTF8 encoded source (ASCII-8BIT) not supported", exc.message)
   end
 
+  def test_source_too_large
+    err = assert_raises(ArgumentError) do
+      tokenize("a" * 2**24)
+    end
+
+    assert_match(/Source too large, max \d+ bytes/, err.message)
+  end
+
   private
 
   def tokenize(source, for_liquid_tag: false, trimmed: false)


### PR DESCRIPTION
Raise when source is larger than 16MiB in `Liquid::Template#parse`. This will let us use this assumption in liquid-c.

See #79.
