### PR TITLE
Inline append filter as an instruction

### DIFF
--- a/ext/liquid_c/util.h
+++ b/ext/liquid_c/util.h
@@ -1,0 +1,7 @@
+#ifndef UTIL_H
+#define UTIL_H
+
+#define MIN(a,b) (((a)>(b))?(b):(a))
+#define MAX(a,b) (((a)<(b))?(b):(a))
+
+#endif

--- a/ext/liquid_c/vm.c
+++ b/ext/liquid_c/vm.c
@@ -290,6 +290,18 @@ static VALUE vm_render_until_error(VALUE uncast_args)
                 break;
             }
 
+            // Filters instructions
+
+            case OP_APPEND:
+            {
+                VALUE *args_ptr = vm_stack_pop_n_use_in_place(vm, 2);
+                VALUE result = rb_str_plus(
+                    rb_obj_as_string(args_ptr[0]),
+                    rb_obj_as_string(args_ptr[1]));
+                vm_stack_push(vm, result);
+                break;
+            }
+
             default:
                 rb_bug("invalid opcode: %u", ip[-1]);
         }
@@ -303,6 +315,7 @@ void liquid_vm_next_instruction(const uint8_t **ip_ptr, const size_t **const_ptr
     switch (*ip++) {
         case OP_LEAVE:
         case OP_POP_WRITE_VARIABLE:
+        case OP_APPEND:
             break;
 
         case OP_HASH_NEW:

--- a/ext/liquid_c/vm_assembler.c
+++ b/ext/liquid_c/vm_assembler.c
@@ -25,6 +25,7 @@ void vm_assembler_gc_mark(vm_assembler_t *code)
         switch (*ip++) {
             case OP_LEAVE:
             case OP_POP_WRITE_VARIABLE:
+            case OP_APPEND:
                 break;
 
             case OP_HASH_NEW:

--- a/ext/liquid_c/vm_assembler.h
+++ b/ext/liquid_c/vm_assembler.h
@@ -3,6 +3,7 @@
 
 #include <assert.h>
 #include "c_buffer.h"
+#include "util.h"
 
 enum opcode {
     OP_LEAVE = 0,
@@ -94,7 +95,10 @@ static inline void vm_assembler_add_push_eval_expr(vm_assembler_t *code, VALUE e
 
 static inline void vm_assembler_add_filter(vm_assembler_t *code, VALUE filter_name, uint8_t arg_count)
 {
-    if (SYM2ID(filter_name) == rb_intern("append")) {
+    // Using rb_sym2id and friends can make it permanent object.
+    VALUE filter_name_str = rb_sym2str(filter_name);
+
+    if (strncmp(RSTRING_PTR(filter_name_str), "append", MIN(RSTRING_LEN(filter_name_str), 6)) == 0) {
         code->stack_size -= 1;
         vm_assembler_write_opcode(code, OP_APPEND);
     } else {


### PR DESCRIPTION
This converts the `| append: ...` filter call into a new `OP_APPEND` VM instruction.

This avoids Ruby method lookup & call, and string duplication (caused by `.to_s`).

My plan is to do something similar for other common, but simple filters. I'm thinking: all the math ones, maybe `escape` (using https://github.com/vmg/houdini)? Also, it set things up for the optimizer I had in mind in https://github.com/Shopify/liquid/pull/1309.

Had a bit of trouble w/ the `test_does_not_permanently_add_filters_to_symbol_table` test. Apparently, calling `rb_sym2id` prevents the symbol from being GCed? A bit weird... So I'm using string compare instead. Any better idea?

### Micro-Benchmark

```
@context['s'] = "x" * 1024
appends = "| append: 'x' " * 10
Template.parse("{{ s #{appends} }}").render(@context)
```

Results:
```
master:
                         62.455k (± 5.6%) i/s -    626.955k in  10.071568s
this PR:
                         76.789k (± 7.4%) i/s -    765.718k in  10.039646s
```
