### PR TITLE
Provide a clearer error message for non-string convertible variable results

### DIFF
--- a/ext/liquid_c/vm.c
+++ b/ext/liquid_c/vm.c
@@ -9,7 +9,6 @@ ID id_render_node;
 ID id_ivar_interrupts;
 ID id_ivar_resource_limits;
 ID id_to_s;
-ID id_to_str;
 ID id_vm;
 ID id_strainer;
 ID id_filter_methods_hash;
@@ -114,28 +113,15 @@ static void write_fixnum(VALUE output, VALUE fixnum)
     snprintf(RSTRING_PTR(output) + old_size, write_length + 1, "%lld", number);
 }
 
-static VALUE obj_check_to_str(VALUE obj)
-{
-    VALUE str = rb_check_funcall(obj, id_to_str, 0, NULL);
-    if (RB_UNLIKELY(str != Qundef && !RB_TYPE_P(str, T_STRING))) {
-        rb_raise(rb_eTypeError, "%"PRIsVALUE"#to_str returned a non-String value of type %"PRIsVALUE,
-                rb_obj_class(obj), rb_obj_class(str));
-    }
-    return str;
-}
-
 static VALUE obj_to_s(VALUE obj)
 {
     VALUE str = rb_funcall(obj, id_to_s, 0);
-    if (RB_TYPE_P(str, T_STRING))
+
+    if (RB_LIKELY(RB_TYPE_P(str, T_STRING)))
         return str;
 
-    VALUE to_str_result = obj_check_to_str(str);
-    if (RB_UNLIKELY(to_str_result == Qundef)) {
-        rb_raise(rb_eTypeError, "%"PRIsVALUE"#to_s returned a non-String convertible value of type %"PRIsVALUE,
-                rb_obj_class(obj), rb_obj_class(str));
-    }
-    return to_str_result;
+    rb_raise(rb_eTypeError, "%"PRIsVALUE"#to_s returned a non-String convertible value of type %"PRIsVALUE,
+            rb_obj_class(obj), rb_obj_class(str));
 }
 
 static void write_obj(VALUE output, VALUE obj)
@@ -427,7 +413,6 @@ void init_liquid_vm()
     id_ivar_interrupts = rb_intern("@interrupts");
     id_ivar_resource_limits = rb_intern("@resource_limits");
     id_to_s = rb_intern("to_s");
-    id_to_str = rb_intern("to_str");
     id_vm = rb_intern("vm");
     id_strainer = rb_intern("strainer");
     id_filter_methods_hash = rb_intern("filter_methods_hash");

--- a/test/unit/variable_test.rb
+++ b/test/unit/variable_test.rb
@@ -137,35 +137,15 @@ class VariableTest < Minitest::Test
     assert_equal("VariableTest::StringConvertible#to_s returned a non-String convertible value of type Integer", exc.message)
   end
 
-  class ImplicitlyStringConvertible
-    def initialize(as_string)
-      @as_string = as_string
-    end
-
+  class DerivedString < String
     def to_s
       self
     end
-
-    def to_str
-      @as_string
-    end
-
-    def to_liquid
-      self
-    end
   end
 
-  def test_write_to_str_convertible_object
-    output = Liquid::Template.parse("{{ obj }}").render!({ 'obj' => ImplicitlyStringConvertible.new('foo') })
-    assert_equal "foo", output
-  end
-
-  def test_write_object_with_broken_to_str
-    template = Liquid::Template.parse("{{ obj }}")
-    exc = assert_raises(TypeError) do
-      template.render!({ 'obj' => ImplicitlyStringConvertible.new(123) })
-    end
-    assert_equal("VariableTest::ImplicitlyStringConvertible#to_str returned a non-String value of type Integer", exc.message)
+  def test_write_derived_string
+    output = Liquid::Template.parse("{{ obj }}").render!({ 'obj' => DerivedString.new('bar') })
+    assert_equal "bar", output
   end
 
   def test_filter_without_args


### PR DESCRIPTION
## Problem

When writing the variable result, the object might first need to be converted to a string.  If that results in an exception, then we get a hard to debug exception that starts with

```
bundler/gems/liquid-c-fe47cb400e86/lib/liquid/c.rb:9:in `render_to_output_buffer': no implicit conversion of nil into String (TypeError)
    from bundler/gems/liquid-c-fe47cb400e86/lib/liquid/c.rb:9:in `render'
```

which shows that it comes from liquid VM rendering, but it doesn't provide enough context on what it was trying to do.  That exception comes from the `StringValue` macro call ruby does in `rb_str_append`.

## Solution

In this situation, the problem is actually with the return value of the `to_s` method, which was being used with `rb_str_append`.  So we want to the exception to be clear about the source of this exception, including specifying the type of the object `to_s` is called on so that we know what method needs fixing.