### PR TITLE
Implement OP_WRITE_RAW on the instructions buffer

### DIFF
--- a/ext/liquid_c/block.c
+++ b/ext/liquid_c/block.c
@@ -278,7 +278,7 @@ static VALUE block_body_remove_blank_strings(VALUE self)
     while (*ip != OP_LEAVE) {
         if (*ip == OP_WRITE_RAW) {
             if (ip[1] || ip[2] || ip[3]) { // if (size != 0)
-                ip[0] = OP_WRITE_RAW_SKIP; // effectively a no-op
+                ip[0] = OP_JUMP_FWD; // effectively a no-op
                 body->render_score--;
             }
         }

--- a/ext/liquid_c/block.c
+++ b/ext/liquid_c/block.c
@@ -33,7 +33,6 @@ typedef struct parse_context {
 static void block_body_mark(void *ptr)
 {
     block_body_t *body = ptr;
-    rb_gc_mark(body->source);
     vm_assembler_gc_mark(&body->code);
 }
 
@@ -67,7 +66,6 @@ static VALUE block_body_allocate(VALUE klass)
     vm_assembler_init(&body->code);
     vm_assembler_add_leave(&body->code);
     body->obj = obj;
-    body->source = Qnil;
     body->render_score = 0;
     body->blank = true;
     body->nodelist = Qundef;
@@ -231,11 +229,6 @@ static VALUE block_body_parse(VALUE self, VALUE tokenizer_obj, VALUE parse_conte
     BlockBody_Get_Struct(self, body);
 
     ensure_not_parsing(body);
-    if (body->source == Qnil) {
-        body->source = parse_context.tokenizer->source;
-    } else if (body->source != parse_context.tokenizer->source) {
-        rb_raise(rb_eArgError, "Liquid::C::BlockBody#parse must be passed the same tokenizer when called multiple times");
-    }
     vm_assembler_remove_leave(&body->code); // to extend block
 
     tag_markup_t unknown_tag = internal_block_body_parse(body, &parse_context);

--- a/ext/liquid_c/block.h
+++ b/ext/liquid_c/block.h
@@ -6,7 +6,6 @@
 typedef struct block_body {
     VALUE obj;
     vm_assembler_t code;
-    VALUE source; // hold a reference to the ruby object that OP_WRITE_RAW points to
     bool blank;
     int render_score;
     VALUE nodelist;

--- a/ext/liquid_c/intutil.h
+++ b/ext/liquid_c/intutil.h
@@ -1,0 +1,22 @@
+#ifndef LIQUID_INTUTIL_H
+#define LIQUID_INTUTIL_H
+
+#include <stdint.h>
+
+static inline unsigned int bytes_to_uint24(const uint8_t *bytes)
+{
+    return (bytes[0] << 16) | (bytes[1] << 8) | bytes[2];
+}
+
+static inline void uint24_to_bytes(unsigned int num, uint8_t *bytes)
+{
+    assert(num < (1 << 24));
+
+    bytes[0] = num >> 16;
+    bytes[1] = num >> 8;
+    bytes[2] = num;
+
+    assert(bytes_to_uint24(bytes) == num);
+}
+
+#endif

--- a/ext/liquid_c/vm.c
+++ b/ext/liquid_c/vm.c
@@ -365,7 +365,7 @@ static VALUE vm_render_until_error(VALUE uncast_args)
                 ip += 3 + size;
                 break;
             }
-            case OP_WRITE_RAW_SKIP:
+            case OP_JUMP_FWD:
             {
                 size_t size = bytes_to_uint24(ip);
                 ip += 3 + size;
@@ -469,7 +469,7 @@ void liquid_vm_next_instruction(const uint8_t **ip_ptr, const size_t **const_ptr
             break;
 
         case OP_WRITE_RAW:
-        case OP_WRITE_RAW_SKIP:
+        case OP_JUMP_FWD:
         {
             size_t size = bytes_to_uint24(ip);
             ip += 3 + size;

--- a/ext/liquid_c/vm_assembler.c
+++ b/ext/liquid_c/vm_assembler.c
@@ -152,9 +152,15 @@ void vm_assembler_require_stack_args(vm_assembler_t *code, unsigned int count)
 
 void vm_assembler_add_write_raw(vm_assembler_t *code, const char *string, size_t size)
 {
-    uint8_t *instructions = c_buffer_extend_for_write(&code->instructions, 4);
-    instructions[0] = OP_WRITE_RAW;
-    uint24_to_bytes((unsigned int)size, &instructions[1]);
+    if (size > UINT8_MAX) {
+        uint8_t *instructions = c_buffer_extend_for_write(&code->instructions, 4);
+        instructions[0] = OP_WRITE_RAW_W;
+        uint24_to_bytes((unsigned int)size, &instructions[1]);
+    } else {
+        uint8_t *instructions = c_buffer_extend_for_write(&code->instructions, 2);
+        instructions[0] = OP_WRITE_RAW;
+        instructions[1] = size;
+    }
 
     c_buffer_write(&code->instructions, (char *)string, size);
 }

--- a/ext/liquid_c/vm_assembler.c
+++ b/ext/liquid_c/vm_assembler.c
@@ -93,15 +93,18 @@ VALUE vm_assembler_disassemble(vm_assembler_t *code)
             {
                 const char *text;
                 size_t size;
+                const char *name;
                 if (*ip == OP_WRITE_RAW_W) {
+                    name = "write_raw_w";
                     size = bytes_to_uint24(&ip[1]);
                     text = (const char *)&ip[4];
                 } else {
+                    name = "write_raw";
                     size = ip[1];
                     text = (const char *)&ip[2];
                 }
                 VALUE string = rb_enc_str_new(text, size, utf8_encoding);
-                rb_str_catf(output, "write_raw(%+"PRIsVALUE")\n", string);
+                rb_str_catf(output, "%s(%+"PRIsVALUE")\n", name, string);
                 break;
             }
 

--- a/ext/liquid_c/vm_assembler.c
+++ b/ext/liquid_c/vm_assembler.c
@@ -88,10 +88,18 @@ VALUE vm_assembler_disassemble(vm_assembler_t *code)
                 break;
             }
 
+            case OP_WRITE_RAW_W:
             case OP_WRITE_RAW:
             {
-                const char *text = (const char *)const_ptr[0];
-                size_t size = const_ptr[1];
+                const char *text;
+                size_t size;
+                if (*ip == OP_WRITE_RAW_W) {
+                    size = bytes_to_uint24(&ip[1]);
+                    text = (const char *)&ip[4];
+                } else {
+                    size = ip[1];
+                    text = (const char *)&ip[2];
+                }
                 VALUE string = rb_enc_str_new(text, size, utf8_encoding);
                 rb_str_catf(output, "write_raw(%+"PRIsVALUE")\n", string);
                 break;

--- a/ext/liquid_c/vm_assembler.h
+++ b/ext/liquid_c/vm_assembler.h
@@ -4,12 +4,14 @@
 #include <assert.h>
 #include "liquid.h"
 #include "c_buffer.h"
+#include "intutil.h"
 
 enum opcode {
     OP_LEAVE = 0,
     OP_WRITE_RAW = 1,
     OP_WRITE_NODE = 2,
     OP_POP_WRITE,
+    OP_WRITE_RAW_SKIP,
     OP_PUSH_CONST,
     OP_PUSH_NIL,
     OP_PUSH_TRUE,
@@ -214,9 +216,7 @@ static inline void vm_assembler_add_render_variable_rescue(vm_assembler_t *code,
 {
     uint8_t *instructions = c_buffer_extend_for_write(&code->instructions, 4);
     instructions[0] = OP_RENDER_VARIABLE_RESCUE;
-    instructions[1] = node_line_number >> 16;
-    instructions[2] = node_line_number >> 8;
-    instructions[3] = node_line_number;
+    uint24_to_bytes((unsigned int)node_line_number, &instructions[1]);
 }
 
 #endif

--- a/ext/liquid_c/vm_assembler.h
+++ b/ext/liquid_c/vm_assembler.h
@@ -27,6 +27,7 @@ enum opcode {
     OP_HASH_NEW, // rb_hash_new & rb_hash_bulk_insert
     OP_FILTER,
     OP_RENDER_VARIABLE_RESCUE, // setup state to rescue variable rendering
+    OP_JUMP_FWD,
 };
 
 typedef struct vm_assembler {

--- a/ext/liquid_c/vm_assembler.h
+++ b/ext/liquid_c/vm_assembler.h
@@ -8,7 +8,7 @@
 
 enum opcode {
     OP_LEAVE = 0,
-    OP_WRITE_RAW = 1,
+    OP_WRITE_RAW_W = 1,
     OP_WRITE_NODE = 2,
     OP_POP_WRITE,
     OP_WRITE_RAW_SKIP,
@@ -27,6 +27,8 @@ enum opcode {
     OP_HASH_NEW, // rb_hash_new & rb_hash_bulk_insert
     OP_FILTER,
     OP_RENDER_VARIABLE_RESCUE, // setup state to rescue variable rendering
+    OP_WRITE_RAW,
+    OP_JUMP_FWD_W,
     OP_JUMP_FWD,
 };
 

--- a/test/unit/block_test.rb
+++ b/test/unit/block_test.rb
@@ -25,6 +25,12 @@ class BlockTest < MiniTest::Test
     assert_equal("üñ", template.render!({ 'unicode_char' => 'ñ' }, output: output))
   end
 
+  def test_op_write_raw_w
+    output = "a" * 2**8
+    template = Liquid::Template.parse(output)
+    assert_equal(output, template.render!)
+  end
+
   def test_disassemble
     source = <<~LIQUID
       raw

--- a/test/unit/block_test.rb
+++ b/test/unit/block_test.rb
@@ -43,16 +43,16 @@ class BlockTest < MiniTest::Test
     assert_instance_of(Liquid::Increment, increment_node)
     assert_equal(<<~ASM, block_body.disassemble)
       0x0000: write_raw("raw")
-      0x0001: render_variable_rescue(line_number: 2)
-      0x0005: find_static_var("var")
-      0x0006: push_const("none")
-      0x0007: push_const("allow_false")
-      0x0008: push_true
-      0x0009: hash_new(1)
-      0x000b: filter(name: :default, num_args: 3)
-      0x000d: pop_write
-      0x000e: write_node(#{increment_node.inspect})
-      0x000f: leave
+      0x0005: render_variable_rescue(line_number: 2)
+      0x0009: find_static_var("var")
+      0x000a: push_const("none")
+      0x000b: push_const("allow_false")
+      0x000c: push_true
+      0x000d: hash_new(1)
+      0x000f: filter(name: :default, num_args: 3)
+      0x0011: pop_write
+      0x0012: write_node(#{increment_node.inspect})
+      0x0013: leave
     ASM
   end
 end

--- a/test/unit/block_test.rb
+++ b/test/unit/block_test.rb
@@ -26,9 +26,19 @@ class BlockTest < MiniTest::Test
   end
 
   def test_op_write_raw_w
-    output = "a" * 2**8
-    template = Liquid::Template.parse(output)
-    assert_equal(output, template.render!)
+    source = "a" * 2**8
+    template = Liquid::Template.parse(source)
+    assert_equal(source, template.render!)
+  end
+
+  def test_disassemble_raw_w
+    source = "a" * 2**8
+    template = Liquid::Template.parse(source)
+    block_body = template.root.body
+    assert_equal(<<~ASM, block_body.disassemble)
+      0x0000: write_raw_w("#{source}")
+      0x0104: leave
+    ASM
   end
 
   def test_disassemble


### PR DESCRIPTION
Implement `OP_WRITE_RAW` as an immediate instruction. The current implementation stores the size as a 24 byte unsigned integer after the instruction and then `size` number of bytes following it is the string. I also added a `OP_WRITE_RAW_SKIP` instruction that skips skips the string. This instruction is used in `BlockBody#remove_blank_strings` to replace `OP_WRITE_RAW` instruction. I'm not entirely satisfied in adding an extra instruction to handle this corner case. I've thought of two other ways to implement this:

1. Store an extra boolean flag to signal whether to skip the instruction or not. The upside to this is that we don't need the special `OP_WRITE_RAW_SKIP` instruction  but will require an extra 8 bytes.
2. Add a function to the `c_buffer` that allows deleting sections from the middle. This is probably the cleanest solution but will have performance overhead of `memmove`.

Also see #77.

# Benchmarks

Base branch:

```
              parse:    156.542  (± 3.2%) i/s -      1.575k in  10.074790s
             render:    222.599  (± 8.1%) i/s -      2.222k in  10.071418s
     parse & render:     85.181  (± 2.3%) i/s -    856.000  in  10.056397s
```

This branch:

```
              parse:    158.134  (± 8.9%) i/s -      1.573k in  10.057410s
             render:    230.214  (± 7.8%) i/s -      2.288k in  10.019494s
     parse & render:     87.223  (± 3.4%) i/s -    876.000  in  10.057597s
```
