### PR TITLE
Provide an internal way to check if we are filtering in a drop method.

### DIFF
--- a/ext/liquid_c/context.c
+++ b/ext/liquid_c/context.c
@@ -1,6 +1,7 @@
 #include "liquid.h"
 #include "context.h"
 #include "variable_lookup.h"
+#include "vm.h"
 
 static VALUE cLiquidVariableLookup, cLiquidUndefinedVariable;
 ID id_aset, id_set_context;
@@ -122,6 +123,14 @@ variable_found:
     return variable;
 }
 
+// Shopify requires checking if we are filtering, so provide a
+// way to do that in liquid-c until we figure out how we want to
+// support that longer term.
+VALUE context_filtering_p(VALUE self)
+{
+    return liquid_vm_filtering(self) ? Qtrue : Qfalse;
+}
+
 void init_liquid_context()
 {
     id_has_key = rb_intern("key?");
@@ -143,4 +152,5 @@ void init_liquid_context()
     VALUE cLiquidContext = rb_const_get(mLiquid, rb_intern("Context"));
     rb_define_method(cLiquidContext, "c_evaluate", context_evaluate, 1);
     rb_define_method(cLiquidContext, "c_find_variable", context_find_variable, 2);
+    rb_define_private_method(cLiquidContext, "c_filtering?", context_filtering_p, 0);
 }

--- a/ext/liquid_c/vm.c
+++ b/ext/liquid_c/vm.c
@@ -94,6 +94,15 @@ static vm_t *vm_from_context(VALUE context)
     return DATA_PTR(vm_obj);
 }
 
+bool liquid_vm_filtering(VALUE context)
+{
+    VALUE vm_obj = rb_attr_get(context, id_vm);
+    if (vm_obj == Qnil)
+        return false;
+    vm_t *vm = DATA_PTR(vm_obj);
+    return vm->invoking_filter;
+}
+
 static void write_fixnum(VALUE output, VALUE fixnum)
 {
     long long number = RB_NUM2LL(fixnum);

--- a/ext/liquid_c/vm.h
+++ b/ext/liquid_c/vm.h
@@ -7,5 +7,6 @@
 void init_liquid_vm();
 void liquid_vm_render(block_body_t *block, VALUE context, VALUE output);
 void liquid_vm_next_instruction(const uint8_t **ip_ptr, const size_t **const_ptr_ptr);
+bool liquid_vm_filtering(VALUE context);
 
 #endif

--- a/test/unit/context_test.rb
+++ b/test/unit/context_test.rb
@@ -55,4 +55,18 @@ class ContextTest < Minitest::Test
     assert_equal 0, called_ruby_method_count
     assert_equal 1, called_c_method_count # context.evaluate call
   end
+
+  class TestDrop < Liquid::Drop
+    def is_filtering
+      @context.send(:c_filtering?)
+    end
+  end
+
+  def test_c_filtering_predicate
+    context = Liquid::Context.new({ 'test' => [TestDrop.new] })
+    template = Liquid::Template.parse('{{ test[0].is_filtering }},{{ test | map: "is_filtering" }}')
+
+    assert_equal "false,true", template.render!(context)
+    assert_equal false, context.send(:c_filtering?)
+  end
 end


### PR DESCRIPTION
cc @Thibaut, @Chris911 

## Problem

We have an ugly hack in Shopify's code for detecting whether a drop method is called from a filter, which uses `caller`.  This breaks when rendering with the liquid VM, since the filter calls are no coming from ruby code.

## Solution

The liquid VM currently already have a boolean to keep track of whether it is filtering to translate `ArgumentError`s on filter calls to `Liquid::ArgumentError`.  So I just exposed this state from a private `Liquid::Context#c_filtering?` method to unblock integration on the liquid VM changes with Shopify.

Longer term, I was planning on getting rid of the invoking_filter boolean from the liquid VM code and check that filters are called with the right number of arguments during parsing (https://github.com/Shopify/liquid/issues/1314).