### PR TITLE
Add an `instrument` option to disable generation of native block bodies

### DIFF
--- a/lib/liquid/c.rb
+++ b/lib/liquid/c.rb
@@ -63,7 +63,10 @@ Liquid::ParseContext.class_eval do
   def disable_liquid_c_nodes
     # Liquid::Profiler exposes the internal parse tree that we don't want to build when
     # parsing with liquid-c, so consider liquid-c to be disabled when using it.
-    @disable_liquid_c_nodes ||= !Liquid::C.enabled || @template_options[:profile]
+    # Also, some templates are parsed before the profiler is running, on which case we
+    # provide the `instrument` option enabled the AST to be produced so the profiler can
+    # use it on future runs.
+    @disable_liquid_c_nodes ||= !Liquid::C.enabled || @template_options[:profile] || @template_options[:instrument]
   end
 end
 

--- a/lib/liquid/c.rb
+++ b/lib/liquid/c.rb
@@ -64,9 +64,9 @@ Liquid::ParseContext.class_eval do
     # Liquid::Profiler exposes the internal parse tree that we don't want to build when
     # parsing with liquid-c, so consider liquid-c to be disabled when using it.
     # Also, some templates are parsed before the profiler is running, on which case we
-    # provide the `instrument` option enabled the AST to be produced so the profiler can
-    # use it on future runs.
-    @disable_liquid_c_nodes ||= !Liquid::C.enabled || @template_options[:profile] || @template_options[:instrument]
+    # provide the `disable_liquid_c_nodes` option to enable the Ruby AST to be produced
+    # so the profiler can use it on future runs.
+    @disable_liquid_c_nodes ||= !Liquid::C.enabled || @template_options[:profile] || @template_options[:disable_liquid_c_nodes]
   end
 end
 


### PR DESCRIPTION
### Problem

As mentioned in https://github.com/Shopify/liquid-c/issues/80#issuecomment-708360946, currently all shops profiled through the Theme Inspector don't see the profiling of the section templates.

<img width="272" alt="Screen Shot 2020-10-13 at 2 32 41 PM" src="https://user-images.githubusercontent.com/22/96037315-ab993e80-0e33-11eb-847e-5f1c5e662044.png">
(This should be 6 levels deep)

### Solution

We need a way to disable generation of native BlockBody::C when profiling will happen later, but don't want to profile yet.

The new option is to be used here: https://github.com/Shopify/storefront-renderer/blob/master/app/liquid/theme_render_context.rb#L265-L269

The name was to imply parse this for profiling (instrument it), but don't profile it. I imagined in the future, it will mean: generate byte-code that is instrumented. But opened to suggestions on the name.