### PR TITLE
Call rb_gc_mark instead of rb_gc_mark_maybe

### DIFF
--- a/ext/liquid_c/c_buffer.h
+++ b/ext/liquid_c/c_buffer.h
@@ -46,4 +46,12 @@ inline void c_buffer_write_ruby_value(c_buffer_t *buffer, VALUE value) {
     c_buffer_write(buffer, &value, sizeof(VALUE));
 }
 
+inline void c_buffer_rb_gc_mark(c_buffer_t *buffer)
+{
+    VALUE *buffer_end = (VALUE *)buffer->data_end;
+    for (VALUE *obj_ptr = (VALUE *)buffer->data; obj_ptr < buffer_end; obj_ptr++) {
+        rb_gc_mark(*obj_ptr);
+    }
+}
+
 #endif

--- a/ext/liquid_c/vm.c
+++ b/ext/liquid_c/vm.c
@@ -32,7 +32,11 @@ typedef struct vm {
 static void vm_mark(void *ptr)
 {
     vm_t *vm = ptr;
-    rb_gc_mark_locations((VALUE *)vm->stack.data, (VALUE *)vm->stack.data_end);
+
+    VALUE *stack_end = (VALUE *)vm->stack.data_end;
+    for (VALUE *obj_ptr = (VALUE *)vm->stack.data; obj_ptr < stack_end; obj_ptr++) {
+        rb_gc_mark(*obj_ptr);
+    }
     rb_gc_mark(vm->strainer);
     rb_gc_mark(vm->filter_methods);
     rb_gc_mark(vm->interrupts);

--- a/ext/liquid_c/vm.c
+++ b/ext/liquid_c/vm.c
@@ -33,10 +33,7 @@ static void vm_mark(void *ptr)
 {
     vm_t *vm = ptr;
 
-    VALUE *stack_end = (VALUE *)vm->stack.data_end;
-    for (VALUE *obj_ptr = (VALUE *)vm->stack.data; obj_ptr < stack_end; obj_ptr++) {
-        rb_gc_mark(*obj_ptr);
-    }
+    c_buffer_rb_gc_mark(&vm->stack);
     rb_gc_mark(vm->strainer);
     rb_gc_mark(vm->filter_methods);
     rb_gc_mark(vm->interrupts);


### PR DESCRIPTION
`rb_gc_mark_locations` is usually used to mark the C stack, so it calls `rb_gc_mark_maybe` for each Ruby object in the memory region (see [here](https://github.com/ruby/ruby/blob/b68c22b3c6a80ebf96d446348bc8007b8a10f694/gc.c#L4957)). `rb_gc_mark_maybe` will only mark if the pointer is to a valid Ruby object. It checks that by performing binary search on the pages on the heap to ensure that the memory address is within a page. This is rather costly when we know that the VM stack only contains pointers to Ruby object so we could directly call `rb_gc_mark`.