### PR TITLE
Fix deprecations and warnings in tests

### DIFF
--- a/test/unit/expression_test.rb
+++ b/test/unit/expression_test.rb
@@ -4,8 +4,8 @@ class ExpressionTest < MiniTest::Test
   def test_literals
     assert_equal true, Liquid::C::Expression.strict_parse('true')
     assert_equal false, Liquid::C::Expression.strict_parse('false')
-    assert_equal nil, Liquid::C::Expression.strict_parse('nil')
-    assert_equal nil, Liquid::C::Expression.strict_parse('null')
+    assert_nil Liquid::C::Expression.strict_parse('nil')
+    assert_nil Liquid::C::Expression.strict_parse('null')
 
     empty = Liquid::C::Expression.strict_parse('empty')
     assert_equal '', empty

--- a/test/unit/expression_test.rb
+++ b/test/unit/expression_test.rb
@@ -14,14 +14,14 @@ class ExpressionTest < MiniTest::Test
 
   def test_byte_int
     assert_equal 127, Liquid::C::Expression.strict_parse('127')
-    assert_equal -128, Liquid::C::Expression.strict_parse('-128')
+    assert_equal(-128, Liquid::C::Expression.strict_parse('-128'))
   end
 
   def test_short_int
     assert_equal 128, Liquid::C::Expression.strict_parse('128')
-    assert_equal -129, Liquid::C::Expression.strict_parse('-129')
+    assert_equal(-129, Liquid::C::Expression.strict_parse('-129'))
     assert_equal 32767, Liquid::C::Expression.strict_parse('32767')
-    assert_equal -32768, Liquid::C::Expression.strict_parse('-32768')
+    assert_equal(-32768, Liquid::C::Expression.strict_parse('-32768'))
   end
 
   def test_float

--- a/test/unit/variable_test.rb
+++ b/test/unit/variable_test.rb
@@ -98,7 +98,6 @@ class VariableTest < Minitest::Test
   end
 
   def test_callbacks
-    variable_parses = 0
     variable_fallbacks = 0
 
     callbacks = {


### PR DESCRIPTION
Fixes the following warnings/deprecations when running tests:

```
DEPRECATED: Use assert_nil if expecting nil from /Users/peter/src/github.com/Shopify/liquid-c/test/unit/expression_test.rb:7. This will fail in Minitest 6.
DEPRECATED: Use assert_nil if expecting nil from /Users/peter/src/github.com/Shopify/liquid-c/test/unit/expression_test.rb:8. This will fail in Minitest 6.
/Users/peter/src/github.com/Shopify/liquid-c/test/unit/expression_test.rb:17: warning: ambiguous first argument; put parentheses or a space even after `-' operator
/Users/peter/src/github.com/Shopify/liquid-c/test/unit/expression_test.rb:22: warning: ambiguous first argument; put parentheses or a space even after `-' operator
/Users/peter/src/github.com/Shopify/liquid-c/test/unit/expression_test.rb:24: warning: ambiguous first argument; put parentheses or a space even after `-' operator
/Users/peter/src/github.com/Shopify/liquid-c/test/unit/variable_test.rb:101: warning: assigned but unused variable - variable_parses
```