### PR TITLE
Compile lax parsed variables and expressions from their ruby objects

### DIFF
--- a/ext/liquid_c/block.c
+++ b/ext/liquid_c/block.c
@@ -68,7 +68,6 @@ static VALUE block_body_allocate(VALUE klass)
     vm_assembler_add_leave(&body->code);
     body->source = Qnil;
     body->render_score = 0;
-    body->parsing = false;
     body->blank = true;
     return obj;
 }
@@ -214,7 +213,7 @@ loop_break:
 
 static void ensure_not_parsing(block_body_t *body)
 {
-    if (body->parsing) {
+    if (body->code.parsing) {
         rb_raise(rb_eRuntimeError, "Liquid::C::BlockBody is in a incompletely parsed state");
     }
 }
@@ -235,12 +234,10 @@ static VALUE block_body_parse(VALUE self, VALUE tokenizer_obj, VALUE parse_conte
     } else if (body->source != parse_context.tokenizer->source) {
         rb_raise(rb_eArgError, "Liquid::C::BlockBody#parse must be passed the same tokenizer when called multiple times");
     }
-    body->parsing = true;
     vm_assembler_remove_leave(&body->code); // to extend block
 
     tag_markup_t unknown_tag = internal_block_body_parse(body, &parse_context);
     vm_assembler_add_leave(&body->code);
-    body->parsing = false;
     return rb_yield_values(2, unknown_tag.name, unknown_tag.markup);
 }
 

--- a/ext/liquid_c/block.c
+++ b/ext/liquid_c/block.c
@@ -331,7 +331,7 @@ static VALUE block_body_nodelist(VALUE self)
                 break;
             }
 
-            case OP_POP_WRITE_VARIABLE:
+            case OP_RENDER_VARIABLE_RESCUE:
                 rb_ary_push(nodelist, variable_placeholder);
                 break;
         }

--- a/ext/liquid_c/block.h
+++ b/ext/liquid_c/block.h
@@ -6,7 +6,6 @@
 typedef struct block_body {
     vm_assembler_t code;
     VALUE source; // hold a reference to the ruby object that OP_WRITE_RAW points to
-    bool parsing; // use to prevent rendering when parsing is incomplete
     bool blank;
     int render_score;
 } block_body_t;

--- a/ext/liquid_c/block.h
+++ b/ext/liquid_c/block.h
@@ -4,6 +4,7 @@
 #include "vm_assembler.h"
 
 typedef struct block_body {
+    VALUE obj;
     vm_assembler_t code;
     VALUE source; // hold a reference to the ruby object that OP_WRITE_RAW points to
     bool blank;

--- a/ext/liquid_c/context.c
+++ b/ext/liquid_c/context.c
@@ -4,7 +4,7 @@
 #include "vm.h"
 #include "expression.h"
 
-static VALUE cLiquidVariableLookup, cLiquidUndefinedVariable;
+static VALUE cLiquidUndefinedVariable;
 ID id_aset, id_set_context;
 static ID id_has_key, id_aref;
 static ID id_ivar_scopes, id_ivar_environments, id_ivar_static_environments, id_ivar_strict_variables;

--- a/ext/liquid_c/liquid.c
+++ b/ext/liquid_c/liquid.c
@@ -15,9 +15,12 @@ ID id_evaluate;
 ID id_to_liquid;
 ID id_to_s;
 ID id_call;
+ID id_compile_evaluate;
 
 VALUE mLiquid, mLiquidC, cLiquidVariable, cLiquidTemplate, cLiquidBlockBody;
+VALUE cLiquidVariableLookup, cLiquidRangeLookup;
 VALUE cLiquidArgumentError, cLiquidSyntaxError, cMemoryError;
+
 rb_encoding *utf8_encoding;
 int utf8_encoding_index;
 
@@ -32,6 +35,7 @@ void Init_liquid_c(void)
     id_to_liquid = rb_intern("to_liquid");
     id_to_s = rb_intern("to_s");
     id_call = rb_intern("call");
+    id_compile_evaluate = rb_intern("compile_evaluate");
 
     utf8_encoding = rb_utf8_encoding();
     utf8_encoding_index = rb_enc_to_index(utf8_encoding);
@@ -59,6 +63,12 @@ void Init_liquid_c(void)
 
     cLiquidBlockBody = rb_const_get(mLiquid, rb_intern("BlockBody"));
     rb_global_variable(&cLiquidBlockBody);
+
+    cLiquidVariableLookup = rb_const_get(mLiquid, rb_intern("VariableLookup"));
+    rb_global_variable(&cLiquidVariableLookup);
+
+    cLiquidRangeLookup = rb_const_get(mLiquid, rb_intern("RangeLookup"));
+    rb_global_variable(&cLiquidRangeLookup);
 
     init_liquid_tokenizer();
     init_liquid_parser();

--- a/ext/liquid_c/liquid.h
+++ b/ext/liquid_c/liquid.h
@@ -9,8 +9,10 @@ extern ID id_evaluate;
 extern ID id_to_liquid;
 extern ID id_to_s;
 extern ID id_call;
+extern ID id_compile_evaluate;
 
 extern VALUE mLiquid, mLiquidC, cLiquidVariable, cLiquidTemplate, cLiquidBlockBody;
+extern VALUE cLiquidVariableLookup, cLiquidRangeLookup;
 extern VALUE cLiquidArgumentError, cLiquidSyntaxError, cMemoryError;
 extern rb_encoding *utf8_encoding;
 extern int utf8_encoding_index;

--- a/ext/liquid_c/variable.c
+++ b/ext/liquid_c/variable.c
@@ -73,7 +73,7 @@ static VALUE try_variable_strict_parse(VALUE uncast_args)
         vm_assembler_add_filter(code, filter_name, arg_count);
     }
 
-    vm_assembler_add_pop_write_variable(code);
+    vm_assembler_add_pop_write(code);
 
     parser_must_consume(&p, TOKEN_EOS);
 

--- a/ext/liquid_c/variable.h
+++ b/ext/liquid_c/variable.h
@@ -2,11 +2,12 @@
 #define LIQUID_VARIABLE_H
 
 #include "vm_assembler.h"
+#include "block.h"
 
 typedef struct variable_parse_args {
     const char *markup;
     const char *markup_end;
-    vm_assembler_t *code;
+    block_body_t *body;
     VALUE parse_context;
     unsigned int line_number;
 } variable_parse_args_t;

--- a/ext/liquid_c/vm.c
+++ b/ext/liquid_c/vm.c
@@ -379,7 +379,7 @@ static VALUE vm_render_until_error(VALUE uncast_args)
                 args->ip = ip;
                 args->const_ptr = const_ptr;
                 break;
-            case OP_POP_WRITE_VARIABLE:
+            case OP_POP_WRITE:
             {
                 VALUE var_result = vm_stack_pop(vm);
                 if (vm->global_filter != Qnil)
@@ -424,7 +424,7 @@ void liquid_vm_next_instruction(const uint8_t **ip_ptr, const size_t **const_ptr
 
     switch (*ip++) {
         case OP_LEAVE:
-        case OP_POP_WRITE_VARIABLE:
+        case OP_POP_WRITE:
         case OP_PUSH_NIL:
         case OP_PUSH_TRUE:
         case OP_PUSH_FALSE:
@@ -495,7 +495,7 @@ static VALUE vm_render_rescue(VALUE uncast_args, VALUE exception)
         do {
             last_op = *ip;
             liquid_vm_next_instruction(&ip, &render_args->const_ptr);
-        } while (last_op != OP_POP_WRITE_VARIABLE);
+        } while (last_op != OP_POP_WRITE);
         render_args->ip = ip;
         // remove temporary stack values from variable evaluation
         vm->stack.data_end = vm->stack.data + args->old_stack_byte_size;

--- a/ext/liquid_c/vm_assembler.c
+++ b/ext/liquid_c/vm_assembler.c
@@ -70,6 +70,19 @@ void vm_assembler_gc_mark(vm_assembler_t *code)
     }
 }
 
+void vm_assembler_concat(vm_assembler_t *dest, vm_assembler_t *src)
+{
+    c_buffer_concat(&dest->instructions, &src->instructions);
+    c_buffer_concat(&dest->constants, &src->constants);
+
+    size_t max_src_stack_size = dest->stack_size + src->max_stack_size;
+    if (max_src_stack_size > dest->max_stack_size)
+        dest->max_stack_size = max_src_stack_size;
+
+    dest->stack_size += src->stack_size;
+}
+
+
 void vm_assembler_add_write_raw(vm_assembler_t *code, const char *string, size_t size)
 {
     vm_assembler_write_opcode(code, OP_WRITE_RAW);

--- a/ext/liquid_c/vm_assembler.c
+++ b/ext/liquid_c/vm_assembler.c
@@ -26,7 +26,7 @@ void vm_assembler_gc_mark(vm_assembler_t *code)
     while (ip < end_ip) {
         switch (*ip++) {
             case OP_LEAVE:
-            case OP_POP_WRITE_VARIABLE:
+            case OP_POP_WRITE:
             case OP_PUSH_NIL:
             case OP_PUSH_TRUE:
             case OP_PUSH_FALSE:

--- a/ext/liquid_c/vm_assembler.c
+++ b/ext/liquid_c/vm_assembler.c
@@ -7,6 +7,7 @@ void vm_assembler_init(vm_assembler_t *code)
     code->constants = c_buffer_allocate(8 * sizeof(VALUE));
     code->max_stack_size = 0;
     code->stack_size = 0;
+    code->parsing = true;
 }
 
 void vm_assembler_free(vm_assembler_t *code)

--- a/ext/liquid_c/vm_assembler.c
+++ b/ext/liquid_c/vm_assembler.c
@@ -1,5 +1,6 @@
 #include "liquid.h"
 #include "vm_assembler.h"
+#include "expression.h"
 
 void vm_assembler_init(vm_assembler_t *code)
 {
@@ -7,6 +8,7 @@ void vm_assembler_init(vm_assembler_t *code)
     code->constants = c_buffer_allocate(8 * sizeof(VALUE));
     code->max_stack_size = 0;
     code->stack_size = 0;
+    code->protected_stack_size = 0;
     code->parsing = true;
 }
 
@@ -83,6 +85,13 @@ void vm_assembler_concat(vm_assembler_t *dest, vm_assembler_t *src)
     dest->stack_size += src->stack_size;
 }
 
+void vm_assembler_require_stack_args(vm_assembler_t *code, unsigned int count)
+{
+    if (code->stack_size < code->protected_stack_size + count) {
+        rb_raise(rb_eRuntimeError, "insufficient number of values on the stack");
+    }
+}
+
 
 void vm_assembler_add_write_raw(vm_assembler_t *code, const char *string, size_t size)
 {
@@ -129,4 +138,104 @@ void vm_assembler_add_push_literal(vm_assembler_t *code, VALUE literal)
         }
         break;
     }
+}
+
+static void ensure_parsing(vm_assembler_t *code)
+{
+    if (!code->parsing)
+        rb_raise(rb_eRuntimeError, "cannot extend code after it has finished being compiled");
+}
+
+void vm_assembler_add_evaluate_expression_from_ruby(vm_assembler_t *code, VALUE code_obj, VALUE expression)
+{
+    ensure_parsing(code);
+
+    if (RB_SPECIAL_CONST_P(expression)) {
+        vm_assembler_add_push_literal(code, expression);
+        return;
+    }
+
+    switch (RB_BUILTIN_TYPE(expression)) {
+        case T_DATA:
+            if (RBASIC_CLASS(expression) == cLiquidCExpression) {
+                vm_assembler_concat(code, &((expression_t *)DATA_PTR(expression))->code);
+                vm_assembler_remove_leave(code);
+                return;
+            }
+            break;
+        case T_OBJECT:
+        {
+            VALUE klass = RBASIC_CLASS(expression);
+            if (klass == cLiquidVariableLookup || klass == cLiquidRangeLookup) {
+                rb_funcall(expression, id_compile_evaluate, 1, code_obj);
+                return;
+            }
+            break;
+        }
+        default:
+            break;
+    }
+    vm_assembler_add_push_const(code, expression);
+}
+
+void vm_assembler_add_find_variable_from_ruby(vm_assembler_t *code, VALUE code_obj, VALUE expression)
+{
+    ensure_parsing(code);
+
+    if (RB_TYPE_P(expression, T_STRING)) {
+        vm_assembler_add_find_static_variable(code, expression);
+    } else {
+        vm_assembler_add_evaluate_expression_from_ruby(code, code_obj, expression);
+        vm_assembler_add_find_variable(code);
+    }
+}
+
+void vm_assembler_add_lookup_command_from_ruby(vm_assembler_t *code, VALUE command)
+{
+    StringValue(command);
+    ensure_parsing(code);
+    vm_assembler_require_stack_args(code, 1);
+
+    vm_assembler_add_lookup_command(code, command);
+}
+
+void vm_assembler_add_lookup_key_from_ruby(vm_assembler_t *code, VALUE code_obj, VALUE expression)
+{
+    ensure_parsing(code);
+    vm_assembler_require_stack_args(code, 1);
+
+    if (RB_TYPE_P(expression, T_STRING)) {
+        vm_assembler_add_lookup_const_key(code, expression);
+    } else {
+        vm_assembler_add_evaluate_expression_from_ruby(code, code_obj, expression);
+        vm_assembler_add_lookup_key(code);
+    }
+}
+
+void vm_assembler_add_new_int_range_from_ruby(vm_assembler_t *code)
+{
+    ensure_parsing(code);
+    vm_assembler_require_stack_args(code, 2);
+    vm_assembler_add_new_int_range(code);
+}
+
+void vm_assembler_add_hash_new_from_ruby(vm_assembler_t *code, VALUE hash_size_obj)
+{
+    ensure_parsing(code);
+    unsigned int hash_size = NUM2USHORT(hash_size_obj);
+    if (hash_size > 255)
+        rb_enc_raise(utf8_encoding, cLiquidSyntaxError, "Hash literal has too many keys");
+    vm_assembler_require_stack_args(code, hash_size * 2);
+
+    vm_assembler_add_hash_new(code, hash_size);
+}
+
+void vm_assembler_add_filter_from_ruby(vm_assembler_t *code, VALUE filter_name, VALUE arg_count_obj)
+{
+    ensure_parsing(code);
+    unsigned int arg_count = NUM2USHORT(arg_count_obj);
+    vm_assembler_require_stack_args(code, arg_count + 1);
+    filter_name = rb_str_intern(filter_name);
+
+    vm_assembler_add_filter(code, filter_name, arg_count);
 }

--- a/ext/liquid_c/vm_assembler.c
+++ b/ext/liquid_c/vm_assembler.c
@@ -223,8 +223,6 @@ void vm_assembler_add_hash_new_from_ruby(vm_assembler_t *code, VALUE hash_size_o
 {
     ensure_parsing(code);
     unsigned int hash_size = NUM2USHORT(hash_size_obj);
-    if (hash_size > 255)
-        rb_enc_raise(utf8_encoding, cLiquidSyntaxError, "Hash literal has too many keys");
     vm_assembler_require_stack_args(code, hash_size * 2);
 
     vm_assembler_add_hash_new(code, hash_size);

--- a/ext/liquid_c/vm_assembler.h
+++ b/ext/liquid_c/vm_assembler.h
@@ -32,6 +32,7 @@ typedef struct vm_assembler {
     c_buffer_t constants;
     size_t max_stack_size;
     size_t stack_size;
+    bool parsing; // prevent executing when incomplete or extending when complete
 } vm_assembler_t;
 
 void init_liquid_vm_assembler();
@@ -77,10 +78,12 @@ static inline void vm_assembler_reserve_stack_size(vm_assembler_t *code, size_t 
 static inline void vm_assembler_add_leave(vm_assembler_t *code)
 {
     vm_assembler_write_opcode(code, OP_LEAVE);
+    code->parsing = false;
 }
 
 static inline void vm_assembler_remove_leave(vm_assembler_t *code)
 {
+    code->parsing = true;
     code->instructions.data_end--;
     assert(*code->instructions.data_end == OP_LEAVE);
 }

--- a/ext/liquid_c/vm_assembler.h
+++ b/ext/liquid_c/vm_assembler.h
@@ -104,8 +104,10 @@ static inline void vm_assembler_add_pop_write(vm_assembler_t *code)
     vm_assembler_write_opcode(code, OP_POP_WRITE);
 }
 
-static inline void vm_assembler_add_hash_new(vm_assembler_t *code, uint8_t hash_size)
+static inline void vm_assembler_add_hash_new(vm_assembler_t *code, size_t hash_size)
 {
+    if (hash_size > 255)
+        rb_enc_raise(utf8_encoding, cLiquidSyntaxError, "Hash literal has too many keys");
     code->stack_size -= hash_size * 2;
     code->stack_size++;
     uint8_t instructions[2] = { OP_HASH_NEW, hash_size };

--- a/ext/liquid_c/vm_assembler.h
+++ b/ext/liquid_c/vm_assembler.h
@@ -38,6 +38,8 @@ void init_liquid_vm_assembler();
 void vm_assembler_init(vm_assembler_t *code);
 void vm_assembler_free(vm_assembler_t *code);
 void vm_assembler_gc_mark(vm_assembler_t *code);
+void vm_assembler_concat(vm_assembler_t *dest, vm_assembler_t *src);
+
 void vm_assembler_add_write_raw(vm_assembler_t *code, const char *string, size_t size);
 void vm_assembler_add_write_node(vm_assembler_t *code, VALUE node);
 void vm_assembler_add_push_fixnum(vm_assembler_t *code, VALUE num);
@@ -69,18 +71,6 @@ static inline void vm_assembler_reserve_stack_size(vm_assembler_t *code, size_t 
 {
     vm_assembler_increment_stack_size(code, amount);
     code->stack_size -= amount;
-}
-
-static inline void vm_assembler_concat(vm_assembler_t *dest, vm_assembler_t *src)
-{
-    c_buffer_concat(&dest->instructions, &src->instructions);
-    c_buffer_concat(&dest->constants, &src->constants);
-
-    size_t max_src_stack_size = dest->stack_size + src->max_stack_size;
-    if (max_src_stack_size > dest->max_stack_size)
-        dest->max_stack_size = max_src_stack_size;
-
-    dest->stack_size += src->stack_size;
 }
 
 

--- a/ext/liquid_c/vm_assembler.h
+++ b/ext/liquid_c/vm_assembler.h
@@ -9,7 +9,7 @@ enum opcode {
     OP_LEAVE = 0,
     OP_WRITE_RAW = 1,
     OP_WRITE_NODE = 2,
-    OP_POP_WRITE_VARIABLE,
+    OP_POP_WRITE,
     OP_PUSH_CONST,
     OP_PUSH_NIL,
     OP_PUSH_TRUE,
@@ -88,10 +88,10 @@ static inline void vm_assembler_remove_leave(vm_assembler_t *code)
     assert(*code->instructions.data_end == OP_LEAVE);
 }
 
-static inline void vm_assembler_add_pop_write_variable(vm_assembler_t *code)
+static inline void vm_assembler_add_pop_write(vm_assembler_t *code)
 {
     code->stack_size -= 1;
-    vm_assembler_write_opcode(code, OP_POP_WRITE_VARIABLE);
+    vm_assembler_write_opcode(code, OP_POP_WRITE);
 }
 
 static inline void vm_assembler_add_hash_new(vm_assembler_t *code, uint8_t hash_size)

--- a/lib/liquid/c.rb
+++ b/lib/liquid/c.rb
@@ -3,6 +3,7 @@
 require 'liquid/c/version'
 require 'liquid'
 require 'liquid_c'
+require 'liquid/c/compile_ext'
 
 Liquid::C::BlockBody.class_eval do
   def render(context)

--- a/lib/liquid/c/compile_ext.rb
+++ b/lib/liquid/c/compile_ext.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+Liquid::Variable.class_eval do
+  def compile_evaluate(code)
+    code.add_evaluate_expression(@name)
+    filters.each do |filter_name, filter_args, keyword_args|
+      filter_args.each do |arg|
+        code.add_evaluate_expression(arg)
+      end
+      num_args = filter_args.size
+      if keyword_args
+        keyword_args.each do |key, value|
+          code.add_evaluate_expression(key)
+          code.add_evaluate_expression(value)
+        end
+        num_args += 1
+        code.add_hash_new(keyword_args.size)
+      end
+      code.add_filter(filter_name, num_args)
+    end
+  end
+end
+
+Liquid::VariableLookup.class_eval do
+  def compile_evaluate(code)
+    code.add_find_variable(name)
+    lookups.each_with_index do |lookup, i|
+      is_command = @command_flags & (1 << i) != 0
+      if is_command
+        code.add_lookup_command(lookup)
+      else
+        code.add_lookup_key(lookup)
+      end
+    end
+  end
+end
+
+Liquid::RangeLookup.class_eval do
+  def compile_evaluate(code)
+    code.add_evaluate_expression(@start_obj)
+    code.add_evaluate_expression(@end_obj)
+    code.add_new_int_range
+  end
+end


### PR DESCRIPTION
## Problem

Currently, we have a fallback to the lax parser that prevents compiling variables to liquid VM code.  Not only does this lose the render performance of the liquid VM, but it is another serialization concern for https://github.com/Shopify/liquid-c/issues/77.  We should get rid of the edge case of having to serialize or render a Liquid::Variable, Liquid::VariableLookup or Liquid::Expression.

## Solution

Start exposing VM assembler methods on the Liquid::C::BlockBody for compiling variables, variable lookups and expressions from ruby code.  Use these in the lax parse fallback for variables.

Note that the VM assembler methods exposed to ruby should be safe to use, such that we can't cause undefined behaviour from trying to render VM instructions added from ruby code.  As such, I have exposed separate vm_assembler_*_from_ruby functions that do additional checking for safety, such as `vm_assembler_require_stack_args` to make sure we will have the required number of values on the stack for the instruction being added.  In the future, we can extend this ruby VM compilation support to allow tags to be compiled from application code.