### PR TITLE
Fix error from calling FIX2INT on a fixnum that doesn't fit in an int

### DIFF
--- a/ext/liquid_c/vm_assembler.c
+++ b/ext/liquid_c/vm_assembler.c
@@ -85,7 +85,7 @@ void vm_assembler_add_write_node(vm_assembler_t *code, VALUE node)
 
 void vm_assembler_add_push_fixnum(vm_assembler_t *code, VALUE num)
 {
-    int x = FIX2INT(num);
+    long x = FIX2LONG(num);
     if (x >= INT8_MIN && x <= INT8_MAX) {
         vm_assembler_add_push_int8(code, x);
     } else if (x >= INT16_MIN && x <= INT16_MAX) {


### PR DESCRIPTION
## Problem

We were getting the following exception

```
bundler/gems/liquid-077bf2a409b9/lib/liquid/block.rb:76:in `parse': integer 3155695200 too big to convert to `int' (RangeError)
```

which seems to be from trying to convert a fixnum into an int in `vm_assembler_add_push_fixnum`.

## Solution

The fix was to simply convert a fixnum into a long instead of an integer.

The expression tests were testing constant fixnums, which don't actually get compiled to optimize for those simple expressions and avoid a possible incompatibility problem.  So I added tests for actually compiling those constants, including a regression test in `test_push_large_fixnum`.