### PR TITLE
Fix stack size calculations for key lookup instructions

### DIFF
--- a/ext/liquid_c/expression.c
+++ b/ext/liquid_c/expression.c
@@ -54,6 +54,7 @@ static VALUE internal_expression_parse(parser_t *p)
     VALUE expr_obj = expression_new(&expression);
 
     parse_and_compile_expression(p, &expression->code);
+    assert(expression->code.stack_size == 1);
     vm_assembler_add_leave(&expression->code);
 
     return expr_obj;

--- a/ext/liquid_c/vm_assembler.h
+++ b/ext/liquid_c/vm_assembler.h
@@ -65,6 +65,12 @@ static inline void vm_assembler_increment_stack_size(vm_assembler_t *code, size_
         code->max_stack_size = code->stack_size;
 }
 
+static inline void vm_assembler_reserve_stack_size(vm_assembler_t *code, size_t amount)
+{
+    vm_assembler_increment_stack_size(code, amount);
+    code->stack_size -= amount;
+}
+
 static inline void vm_assembler_concat(vm_assembler_t *dest, vm_assembler_t *src)
 {
     c_buffer_concat(&dest->instructions, &src->instructions);
@@ -158,20 +164,20 @@ static inline void vm_assembler_add_find_variable(vm_assembler_t *code)
 
 static inline void vm_assembler_add_lookup_const_key(vm_assembler_t *code, VALUE key)
 {
-    vm_assembler_increment_stack_size(code, 1);
+    vm_assembler_reserve_stack_size(code, 1); // push 1, pop 2, push 1
     vm_assembler_write_ruby_constant(code, key);
     vm_assembler_write_opcode(code, OP_LOOKUP_CONST_KEY);
 }
 
 static inline void vm_assembler_add_lookup_key(vm_assembler_t *code)
 {
-    // pop 1, push 1
+    code->stack_size--; // pop 2, push 1
     vm_assembler_write_opcode(code, OP_LOOKUP_KEY);
 }
 
 static inline void vm_assembler_add_lookup_command(vm_assembler_t *code, VALUE command)
 {
-    vm_assembler_increment_stack_size(code, 1);
+    vm_assembler_reserve_stack_size(code, 1); // push 1, pop 2, push 1
     vm_assembler_write_ruby_constant(code, command);
     vm_assembler_write_opcode(code, OP_LOOKUP_COMMAND);
 }


### PR DESCRIPTION
## Problem

I tried adding an assertion in `internal_expression_parse` to make sure the expression evaluates to exactly one value and got an assertion error when running the tests.  It looks like the lookup key instructions were overestimated the stack size, causing more space to be reserved on the stack than needed.

## Solution

Add the assertion along with fixes for the stack size adjustments in the add lookup key instruction functions.