### PR TITLE
Store some Liquid::Context instance variables in the VM

### DIFF
--- a/ext/liquid_c/context.c
+++ b/ext/liquid_c/context.c
@@ -10,6 +10,33 @@ ID id_aset, id_set_context;
 static ID id_has_key, id_aref;
 static ID id_ivar_scopes, id_ivar_environments, id_ivar_static_environments, id_ivar_strict_variables;
 
+void context_internal_init(VALUE context_obj, context_t *context)
+{
+    context->self = context_obj;
+
+    context->environments = rb_ivar_get(context_obj, id_ivar_environments);
+    Check_Type(context->environments, T_ARRAY);
+
+    context->static_environments = rb_ivar_get(context_obj, id_ivar_static_environments);
+    Check_Type(context->static_environments, T_ARRAY);
+
+    context->scopes = rb_ivar_get(context_obj, id_ivar_scopes);
+    Check_Type(context->scopes, T_ARRAY);
+}
+
+void context_mark(context_t *context)
+{
+    rb_gc_mark(context->self);
+    rb_gc_mark(context->environments);
+    rb_gc_mark(context->static_environments);
+    rb_gc_mark(context->scopes);
+}
+
+static context_t *context_from_obj(VALUE self)
+{
+    return &vm_from_context(self)->context;
+}
+
 static VALUE context_evaluate(VALUE self, VALUE expression)
 {
     // Scalar type stored directly in the VALUE, this needs to be checked anyways to use RB_BUILTIN_TYPE
@@ -79,13 +106,12 @@ static bool environments_find_variable(VALUE environments, VALUE key, VALUE stri
     return false;
 }
 
-VALUE context_find_variable(VALUE self, VALUE key, VALUE raise_on_not_found)
+VALUE context_find_variable(context_t *context, VALUE key, VALUE raise_on_not_found)
 {
+    VALUE self = context->self;
     VALUE scope = Qnil, variable = Qnil;
 
-    VALUE scopes = rb_ivar_get(self, id_ivar_scopes);
-    Check_Type(scopes, T_ARRAY);
-
+    VALUE scopes = context->scopes;
     for (long i = 0; i < RARRAY_LEN(scopes); i++) {
         VALUE this_scope = RARRAY_AREF(scopes, i);
         if (RB_LIKELY(TYPE(this_scope) == T_HASH)) {
@@ -106,12 +132,10 @@ VALUE context_find_variable(VALUE self, VALUE key, VALUE raise_on_not_found)
 
     VALUE strict_variables = rb_ivar_get(self, id_ivar_strict_variables);
 
-    VALUE environments = rb_ivar_get(self, id_ivar_environments);
-    if (environments_find_variable(environments, key, strict_variables, raise_on_not_found, &scope, &variable))
+    if (environments_find_variable(context->environments, key, strict_variables, raise_on_not_found, &scope, &variable))
         goto variable_found;
 
-    VALUE static_environments = rb_ivar_get(self, id_ivar_static_environments);
-    if (environments_find_variable(static_environments, key, strict_variables, raise_on_not_found, &scope, &variable))
+    if (environments_find_variable(context->static_environments, key, strict_variables, raise_on_not_found, &scope, &variable))
         goto variable_found;
 
     if (RTEST(raise_on_not_found)) {
@@ -124,6 +148,11 @@ variable_found:
     variable = value_to_liquid_and_set_context(variable, self);
 
     return variable;
+}
+
+static VALUE context_find_variable_method(VALUE self, VALUE key, VALUE raise_on_not_found)
+{
+    return context_find_variable(context_from_obj(self), key, raise_on_not_found);
 }
 
 // Shopify requires checking if we are filtering, so provide a
@@ -154,6 +183,6 @@ void init_liquid_context()
 
     VALUE cLiquidContext = rb_const_get(mLiquid, rb_intern("Context"));
     rb_define_method(cLiquidContext, "c_evaluate", context_evaluate, 1);
-    rb_define_method(cLiquidContext, "c_find_variable", context_find_variable, 2);
+    rb_define_method(cLiquidContext, "c_find_variable", context_find_variable_method, 2);
     rb_define_private_method(cLiquidContext, "c_filtering?", context_filtering_p, 0);
 }

--- a/ext/liquid_c/context.c
+++ b/ext/liquid_c/context.c
@@ -30,6 +30,11 @@ void context_mark(context_t *context)
     rb_gc_mark(context->environments);
     rb_gc_mark(context->static_environments);
     rb_gc_mark(context->scopes);
+    rb_gc_mark(context->strainer);
+    rb_gc_mark(context->filter_methods);
+    rb_gc_mark(context->interrupts);
+    rb_gc_mark(context->resource_limits_obj);
+    rb_gc_mark(context->global_filter);
 }
 
 static context_t *context_from_obj(VALUE self)

--- a/ext/liquid_c/context.h
+++ b/ext/liquid_c/context.h
@@ -1,8 +1,17 @@
 #if !defined(LIQUID_CONTEXT_H)
 #define LIQUID_CONTEXT_H
 
+typedef struct context {
+    VALUE self;
+    VALUE environments;
+    VALUE static_environments;
+    VALUE scopes;
+} context_t;
+
 void init_liquid_context();
-VALUE context_find_variable(VALUE self, VALUE key, VALUE raise_on_not_found);
+void context_internal_init(VALUE context_obj, context_t *context);
+void context_mark(context_t *context);
+VALUE context_find_variable(context_t *context, VALUE key, VALUE raise_on_not_found);
 void context_maybe_raise_undefined_variable(VALUE self, VALUE key);
 
 extern ID id_aset, id_set_context;

--- a/ext/liquid_c/context.h
+++ b/ext/liquid_c/context.h
@@ -1,11 +1,20 @@
 #if !defined(LIQUID_CONTEXT_H)
 #define LIQUID_CONTEXT_H
 
+#include "resource_limits.h"
+
 typedef struct context {
     VALUE self;
     VALUE environments;
     VALUE static_environments;
     VALUE scopes;
+    VALUE strainer;
+    VALUE filter_methods;
+    VALUE interrupts;
+    VALUE resource_limits_obj;
+    resource_limits_t *resource_limits;
+    VALUE global_filter;
+    bool strict_filters;
 } context_t;
 
 void init_liquid_context();

--- a/ext/liquid_c/context.h
+++ b/ext/liquid_c/context.h
@@ -14,6 +14,7 @@ typedef struct context {
     VALUE resource_limits_obj;
     resource_limits_t *resource_limits;
     VALUE global_filter;
+    bool strict_variables;
     bool strict_filters;
 } context_t;
 

--- a/ext/liquid_c/vm.c
+++ b/ext/liquid_c/vm.c
@@ -12,6 +12,7 @@ ID id_ivar_resource_limits;
 ID id_vm;
 ID id_strainer;
 ID id_filter_methods_hash;
+ID id_strict_variables;
 ID id_strict_filters;
 ID id_global_filter;
 
@@ -62,6 +63,7 @@ static VALUE vm_internal_new(VALUE context)
     vm->context.resource_limits_obj = rb_ivar_get(context, id_ivar_resource_limits);;
     ResourceLimits_Get_Struct(vm->context.resource_limits_obj, vm->context.resource_limits);
 
+    vm->context.strict_variables = false;
     vm->context.strict_filters = RTEST(rb_funcall(context, id_strict_filters, 0));
     vm->context.global_filter = rb_funcall(context, id_global_filter, 0);
     vm->invoking_filter = false;
@@ -575,6 +577,7 @@ void init_liquid_vm()
     id_vm = rb_intern("vm");
     id_strainer = rb_intern("strainer");
     id_filter_methods_hash = rb_intern("filter_methods_hash");
+    id_strict_variables = rb_intern("strict_variables");
     id_strict_filters = rb_intern("strict_filters");
     id_global_filter = rb_intern("global_filter");
 

--- a/ext/liquid_c/vm.c
+++ b/ext/liquid_c/vm.c
@@ -7,14 +7,7 @@
 #include "intutil.h"
 
 ID id_render_node;
-ID id_ivar_interrupts;
-ID id_ivar_resource_limits;
 ID id_vm;
-ID id_strainer;
-ID id_filter_methods_hash;
-ID id_strict_variables;
-ID id_strict_filters;
-ID id_global_filter;
 
 static VALUE cLiquidCVM;
 
@@ -51,21 +44,6 @@ static VALUE vm_internal_new(VALUE context)
     VALUE obj = TypedData_Make_Struct(cLiquidCVM, vm_t, &vm_data_type, vm);
     vm->stack = c_buffer_init();
 
-    vm->context.strainer = rb_funcall(context, id_strainer, 0);
-    Check_Type(vm->context.strainer, T_OBJECT);
-
-    vm->context.filter_methods = rb_funcall(RBASIC_CLASS(vm->context.strainer), id_filter_methods_hash, 0);
-    Check_Type(vm->context.filter_methods, T_HASH);
-
-    vm->context.interrupts = rb_ivar_get(context, id_ivar_interrupts);
-    Check_Type(vm->context.interrupts, T_ARRAY);
-
-    vm->context.resource_limits_obj = rb_ivar_get(context, id_ivar_resource_limits);;
-    ResourceLimits_Get_Struct(vm->context.resource_limits_obj, vm->context.resource_limits);
-
-    vm->context.strict_variables = false;
-    vm->context.strict_filters = RTEST(rb_funcall(context, id_strict_filters, 0));
-    vm->context.global_filter = rb_funcall(context, id_global_filter, 0);
     vm->invoking_filter = false;
 
     context_internal_init(context, &vm->context);
@@ -572,14 +550,7 @@ void liquid_vm_render(block_body_t *body, VALUE context, VALUE output)
 void init_liquid_vm()
 {
     id_render_node = rb_intern("render_node");
-    id_ivar_interrupts = rb_intern("@interrupts");
-    id_ivar_resource_limits = rb_intern("@resource_limits");
     id_vm = rb_intern("vm");
-    id_strainer = rb_intern("strainer");
-    id_filter_methods_hash = rb_intern("filter_methods_hash");
-    id_strict_variables = rb_intern("strict_variables");
-    id_strict_filters = rb_intern("strict_filters");
-    id_global_filter = rb_intern("global_filter");
 
     cLiquidCVM = rb_define_class_under(mLiquidC, "VM", rb_cObject);
     rb_undef_alloc_func(cLiquidCVM);

--- a/ext/liquid_c/vm.c
+++ b/ext/liquid_c/vm.c
@@ -3,8 +3,6 @@
 
 #include "liquid.h"
 #include "vm.h"
-#include "resource_limits.h"
-#include "context.h"
 #include "variable_lookup.h"
 #include "intutil.h"
 
@@ -19,18 +17,6 @@ ID id_global_filter;
 
 static VALUE cLiquidCVM;
 
-struct vm {
-    c_buffer_t stack;
-    VALUE strainer;
-    VALUE filter_methods;
-    VALUE interrupts;
-    VALUE resource_limits_obj;
-    resource_limits_t *resource_limits;
-    VALUE global_filter;
-    bool strict_filters;
-    bool invoking_filter;
-};
-
 static void vm_mark(void *ptr)
 {
     vm_t *vm = ptr;
@@ -41,6 +27,7 @@ static void vm_mark(void *ptr)
     rb_gc_mark(vm->interrupts);
     rb_gc_mark(vm->resource_limits_obj);
     rb_gc_mark(vm->global_filter);
+    context_mark(&vm->context);
 }
 
 static void vm_free(void *ptr)
@@ -83,6 +70,9 @@ static VALUE vm_internal_new(VALUE context)
     vm->strict_filters = RTEST(rb_funcall(context, id_strict_filters, 0));
     vm->global_filter = rb_funcall(context, id_global_filter, 0);
     vm->invoking_filter = false;
+
+    context_internal_init(context, &vm->context);
+
     return obj;
 }
 
@@ -219,7 +209,6 @@ typedef struct vm_render_until_error_args {
     vm_t *vm;
     const uint8_t *ip; // use for initial address and to save an address for rescuing
     const size_t *const_ptr;
-    VALUE context;
 
     /* rendering fields */
     VALUE output;
@@ -308,7 +297,7 @@ static VALUE vm_render_until_error(VALUE uncast_args)
             case OP_FIND_VAR:
             {
                 VALUE key = vm_stack_pop(vm);
-                VALUE value = context_find_variable(args->context, key, Qtrue);
+                VALUE value = context_find_variable(&vm->context, key, Qtrue);
                 vm_stack_push(vm, value);
                 break;
             }
@@ -321,7 +310,7 @@ static VALUE vm_render_until_error(VALUE uncast_args)
                 bool is_command = ip[-1] == OP_LOOKUP_COMMAND;
                 VALUE key = vm_stack_pop(vm);
                 VALUE object = vm_stack_pop(vm);
-                VALUE result = variable_lookup_key(args->context, object, key, is_command);
+                VALUE result = variable_lookup_key(vm->context.self, object, key, is_command);
                 vm_stack_push(vm, result);
                 break;
             }
@@ -389,7 +378,7 @@ static VALUE vm_render_until_error(VALUE uncast_args)
             }
 
             case OP_WRITE_NODE:
-                rb_funcall(cLiquidBlockBody, id_render_node, 3, args->context, output, (VALUE)*const_ptr++);
+                rb_funcall(cLiquidBlockBody, id_render_node, 3, vm->context.self, output, (VALUE)*const_ptr++);
                 if (RARRAY_LEN(vm->interrupts)) {
                     return false;
                 }
@@ -434,8 +423,7 @@ VALUE liquid_vm_evaluate(VALUE context, vm_assembler_t *code)
     vm_render_until_error_args_t args = {
         .vm = vm,
         .const_ptr = (const size_t *)code->constants.data,
-        .ip = code->instructions.data,
-        .context = context,
+        .ip = code->instructions.data
     };
     vm_render_until_error((VALUE)&args);
     VALUE ret = vm_stack_pop(vm);
@@ -556,7 +544,7 @@ static VALUE vm_render_rescue(VALUE uncast_args, VALUE exception)
     }
 
     rb_funcall(cLiquidBlockBody, rb_intern("c_rescue_render_node"), 5,
-        render_args->context, render_args->output, line_number, exception, blank_tag);
+        vm->context.self, render_args->output, line_number, exception, blank_tag);
     return true;
 }
 
@@ -571,7 +559,6 @@ void liquid_vm_render(block_body_t *body, VALUE context, VALUE output)
         .vm = vm,
         .const_ptr = (const size_t *)body->code.constants.data,
         .ip = body->code.instructions.data,
-        .context = context,
         .output = output,
     };
     vm_render_rescue_args_t rescue_args = {

--- a/ext/liquid_c/vm.h
+++ b/ext/liquid_c/vm.h
@@ -3,10 +3,24 @@
 
 #include <ruby.h>
 #include "block.h"
+#include "context.h"
+#include "resource_limits.h"
 
-typedef struct vm vm_t;
+typedef struct vm {
+    c_buffer_t stack;
+    VALUE strainer;
+    VALUE filter_methods;
+    VALUE interrupts;
+    VALUE resource_limits_obj;
+    resource_limits_t *resource_limits;
+    VALUE global_filter;
+    bool strict_filters;
+    bool invoking_filter;
+    context_t context;
+} vm_t;
 
 void init_liquid_vm();
+vm_t *vm_from_context(VALUE context);
 void liquid_vm_render(block_body_t *block, VALUE context, VALUE output);
 void liquid_vm_next_instruction(const uint8_t **ip_ptr, const size_t **const_ptr_ptr);
 bool liquid_vm_filtering(VALUE context);

--- a/ext/liquid_c/vm.h
+++ b/ext/liquid_c/vm.h
@@ -4,17 +4,9 @@
 #include <ruby.h>
 #include "block.h"
 #include "context.h"
-#include "resource_limits.h"
 
 typedef struct vm {
     c_buffer_t stack;
-    VALUE strainer;
-    VALUE filter_methods;
-    VALUE interrupts;
-    VALUE resource_limits_obj;
-    resource_limits_t *resource_limits;
-    VALUE global_filter;
-    bool strict_filters;
     bool invoking_filter;
     context_t context;
 } vm_t;

--- a/lib/liquid/c.rb
+++ b/lib/liquid/c.rb
@@ -195,6 +195,7 @@ end
 Liquid::Context.class_eval do
   alias_method :ruby_evaluate, :evaluate
   alias_method :ruby_find_variable, :find_variable
+  alias_method :ruby_strict_variables=, :strict_variables=
 
   # This isn't entered often by Ruby (most calls stay in C via VariableLookup#evaluate)
   # so the wrapper method isn't costly.
@@ -227,10 +228,12 @@ module Liquid
         if value
           Liquid::Context.send(:alias_method, :evaluate, :c_evaluate)
           Liquid::Context.send(:alias_method, :find_variable, :c_find_variable_kwarg)
+          Liquid::Context.send(:alias_method, :strict_variables=, :c_strict_variables=)
           Liquid::Raw.send(:alias_method, :parse, :c_parse)
         else
           Liquid::Context.send(:alias_method, :evaluate, :ruby_evaluate)
           Liquid::Context.send(:alias_method, :find_variable, :ruby_find_variable)
+          Liquid::Context.send(:alias_method, :strict_variables=, :ruby_strict_variables=)
           Liquid::Raw.send(:alias_method, :parse, :ruby_parse)
         end
       end

--- a/test/unit/context_test.rb
+++ b/test/unit/context_test.rb
@@ -72,4 +72,11 @@ class ContextTest < Minitest::Test
     assert_equal("false,true", template.render!(context))
     assert_equal(false, context.send(:c_filtering?))
   end
+
+  def test_strict_variables=
+    context = Liquid::Context.new
+    assert_equal(false, context.strict_variables)
+    context.strict_variables = true
+    assert_equal(true, context.strict_variables)
+  end
 end


### PR DESCRIPTION
Store the `@environments`, `@static_environments`, `@scopes` variables of `Liquid::Context` in the VM (inside the `context_t` struct). This means we don't need to fetch these instance variables every time we call `Liquid::Context#find_variable`.

I didn't store the `@strict_variables` variable because it's a writable attribute (so it could change from initialization).
