### PR TITLE
Compile using -O0 in debugging

### DIFF
--- a/ext/liquid_c/c_buffer.h
+++ b/ext/liquid_c/c_buffer.h
@@ -9,28 +9,28 @@ typedef struct c_buffer {
     uint8_t *capacity_end;
 } c_buffer_t;
 
-inline c_buffer_t c_buffer_init()
+static inline c_buffer_t c_buffer_init()
 {
     return (c_buffer_t) { NULL, NULL, NULL };
 }
 
-inline c_buffer_t c_buffer_allocate(size_t capacity)
+static inline c_buffer_t c_buffer_allocate(size_t capacity)
 {
     uint8_t *data = xmalloc(capacity);
     return (c_buffer_t) { data, data, data + capacity };
 }
 
-inline void c_buffer_free(c_buffer_t *buffer)
+static inline void c_buffer_free(c_buffer_t *buffer)
 {
     xfree(buffer->data);
 }
 
-inline size_t c_buffer_size(const c_buffer_t *buffer)
+static inline size_t c_buffer_size(const c_buffer_t *buffer)
 {
     return buffer->data_end - buffer->data;
 }
 
-inline size_t c_buffer_capacity(const c_buffer_t *buffer)
+static inline size_t c_buffer_capacity(const c_buffer_t *buffer)
 {
     return buffer->capacity_end - buffer->data;
 }
@@ -38,15 +38,15 @@ inline size_t c_buffer_capacity(const c_buffer_t *buffer)
 void c_buffer_reserve_for_write(c_buffer_t *buffer, size_t write_size);
 void c_buffer_write(c_buffer_t *buffer, void *data, size_t size);
 
-inline void c_buffer_write_byte(c_buffer_t *buffer, uint8_t byte) {
+static inline void c_buffer_write_byte(c_buffer_t *buffer, uint8_t byte) {
     c_buffer_write(buffer, &byte, 1);
 }
 
-inline void c_buffer_write_ruby_value(c_buffer_t *buffer, VALUE value) {
+static inline void c_buffer_write_ruby_value(c_buffer_t *buffer, VALUE value) {
     c_buffer_write(buffer, &value, sizeof(VALUE));
 }
 
-inline void c_buffer_rb_gc_mark(c_buffer_t *buffer)
+static inline void c_buffer_rb_gc_mark(c_buffer_t *buffer)
 {
     VALUE *buffer_end = (VALUE *)buffer->data_end;
     for (VALUE *obj_ptr = (VALUE *)buffer->data; obj_ptr < buffer_end; obj_ptr++) {
@@ -54,7 +54,7 @@ inline void c_buffer_rb_gc_mark(c_buffer_t *buffer)
     }
 }
 
-inline void c_buffer_concat(c_buffer_t *dest, c_buffer_t *src)
+static inline void c_buffer_concat(c_buffer_t *dest, c_buffer_t *src)
 {
     c_buffer_write(dest, src->data, c_buffer_size(src));
 }

--- a/ext/liquid_c/extconf.rb
+++ b/ext/liquid_c/extconf.rb
@@ -8,6 +8,7 @@ if ENV['DEBUG'] == 'true'
   if compiler =~ /gcc|g\+\+/
     $CFLAGS << ' -fbounds-check'
   end
+  CONFIG['optflags'] = ' -O0'
 else
   $CFLAGS << ' -DNDEBUG'
 end

--- a/ext/liquid_c/liquid.h
+++ b/ext/liquid_c/liquid.h
@@ -19,7 +19,7 @@ extern int utf8_encoding_index;
 
 __attribute__((noreturn)) void raise_non_utf8_encoding_error(VALUE string, const char *string_name);
 
-inline void check_utf8_encoding(VALUE string, const char *string_name)
+static inline void check_utf8_encoding(VALUE string, const char *string_name)
 {
     if (RB_UNLIKELY(RB_ENCODING_GET_INLINED(string) != utf8_encoding_index))
         raise_non_utf8_encoding_error(string, string_name);


### PR DESCRIPTION
Compile using `-O0` in debugging to prevent optimizations from erasing functions and variables that can no longer be accessed in a debugger.

`inline` functions are only possibly inlined at `-O2` and higher. Without the `static` keyword, these inline functions are supposed to exist externally. Which means that they fail to run when they are not inlined (since it can't find these functions that don't exist externally). The solution is to add the `static` keyword to the `inline` functions. Many thanks to @dylanahsmith for helping me debug this!

See this SO answer for more info: https://stackoverflow.com/a/41218504/3878329