### PR TITLE
Fix lookup on variable with literal name

### DIFF
--- a/ext/liquid_c/parser.c
+++ b/ext/liquid_c/parser.c
@@ -146,6 +146,9 @@ static void parse_and_compile_variable_lookup(parser_t *p, vm_assembler_t *code)
 
 static VALUE try_parse_literal(parser_t *p)
 {
+    if (p->next.type == TOKEN_DOT || p->next.type == TOKEN_OPEN_SQUARE)
+        return Qundef;
+
     const char *str = p->cur.val;
     long size = p->cur.val_end - str;
     VALUE result = Qundef;

--- a/test/unit/expression_test.rb
+++ b/test/unit/expression_test.rb
@@ -119,6 +119,13 @@ class ExpressionTest < MiniTest::Test
     end
   end
 
+  def test_lookup_on_var_with_literal_name
+    context = Liquid::Context.new({ "blank" => { "x" => "result" } })
+
+    assert_equal("result", context.evaluate(Liquid::C::Expression.strict_parse('blank.x')))
+    assert_equal("result", context.evaluate(Liquid::C::Expression.strict_parse('blank["x"]')))
+  end
+
   def test_const_range
     assert_equal (1..2), Liquid::C::Expression.strict_parse('(1..2)')
   end

--- a/test/unit/variable_test.rb
+++ b/test/unit/variable_test.rb
@@ -37,6 +37,8 @@ class VariableTest < Minitest::Test
     assert_equal 'blank_value', variable_strict_parse('[blank]').render!({ '' => 'blank_value' })
     assert_equal 'result', variable_strict_parse('[true][blank]').render!({ true => { '' => 'result' } })
     assert_equal 'result', variable_strict_parse('x["size"]').render!({ 'x' => { 'size' => 'result' } })
+    assert_equal 'result', variable_strict_parse('blank.x').render!({ 'blank' => { 'x' => 'result' } })
+    assert_equal 'result', variable_strict_parse('blank["x"]').render!({ 'blank' => { 'x' => 'result' } })
   end
 
   module InspectCallFilters


### PR DESCRIPTION
## Problem

https://github.com/Shopify/liquid-c/pull/60 introduced a subtle regression for doing a lookup on a variable with a name that matches a literal.

For example,

```ruby
Liquid::Template.parse("{{ blank.svg | asset_url }}", error_mode: :strict)
```

would result in the following error after that pull request was introduced

```
Liquid::SyntaxError (Liquid syntax error: Expected end_of_string but found dot in "{{ blank.svg | asset_url }}")
```

but we would get the strict parse error on the commit before that PR was merged or when just using the liquid gem.

This quirk comes from the [`LITERALS.key?(markup)`](https://github.com/Shopify/liquid/blob/8e99b3bd7f541afce4e4690c165584c4b8fdc150/lib/liquid/expression.rb#L20-L21) check being used to detect if the markup is for a literal.  If that literal name is followed by an object lookup (e.g. `.svg`) then it is handled by VariableLookup which will treat the literal name (e.g. `blank`) as the variable name.

## Solution

Lookahead to make sure the identifier isn't followed by a `.` or `[` token before treating it as a literal.