### PR TITLE
Set @line_number directly on the Liquid::ParseContext

### DIFF
--- a/ext/liquid_c/block.c
+++ b/ext/liquid_c/block.c
@@ -12,7 +12,6 @@ static ID
     intern_is_blank,
     intern_parse,
     intern_square_brackets,
-    intern_set_line_number,
     intern_unknown_tag_in_liquid_tag,
     intern_ivar_nodelist;
 
@@ -88,7 +87,7 @@ static tag_markup_t internal_block_body_parse(block_body_t *body, parse_context_
     while (true) {
         int token_start_line_number = tokenizer->line_number;
         if (token_start_line_number != 0) {
-            rb_funcall(parse_context->ruby_obj, intern_set_line_number, 1, UINT2NUM(token_start_line_number));
+            rb_ivar_set(parse_context->ruby_obj, id_ivar_line_number, UINT2NUM(token_start_line_number));
         }
         tokenizer_next(tokenizer, &token);
 
@@ -409,7 +408,6 @@ void init_liquid_block()
     intern_is_blank = rb_intern("blank?");
     intern_parse = rb_intern("parse");
     intern_square_brackets = rb_intern("[]");
-    intern_set_line_number = rb_intern("line_number=");
     intern_unknown_tag_in_liquid_tag = rb_intern("unknown_tag_in_liquid_tag");
     intern_ivar_nodelist = rb_intern("@nodelist");
 

--- a/ext/liquid_c/liquid.c
+++ b/ext/liquid_c/liquid.c
@@ -16,6 +16,7 @@ ID id_to_liquid;
 ID id_to_s;
 ID id_call;
 ID id_compile_evaluate;
+ID id_ivar_line_number;
 
 VALUE mLiquid, mLiquidC, cLiquidVariable, cLiquidTemplate, cLiquidBlockBody;
 VALUE cLiquidVariableLookup, cLiquidRangeLookup;
@@ -36,6 +37,7 @@ void Init_liquid_c(void)
     id_to_s = rb_intern("to_s");
     id_call = rb_intern("call");
     id_compile_evaluate = rb_intern("compile_evaluate");
+    id_ivar_line_number = rb_intern("@line_number");
 
     utf8_encoding = rb_utf8_encoding();
     utf8_encoding_index = rb_enc_to_index(utf8_encoding);

--- a/ext/liquid_c/liquid.h
+++ b/ext/liquid_c/liquid.h
@@ -10,6 +10,7 @@ extern ID id_to_liquid;
 extern ID id_to_s;
 extern ID id_call;
 extern ID id_compile_evaluate;
+extern ID id_ivar_line_number;
 
 extern VALUE mLiquid, mLiquidC, cLiquidVariable, cLiquidTemplate, cLiquidBlockBody;
 extern VALUE cLiquidVariableLookup, cLiquidRangeLookup;


### PR DESCRIPTION
`Liquid::ParseContext` uses an `attr_accessor` for the line number.  Right now liquid-c is calling `Liquid::ParseContext#line_number=` to set that attribute, but it would be faster to just call `rb_ivar_set`.  Also, this will let me re-use the same ID for re-using with `rb_attr_get`, which I will need for Liquid::Assign.compile in https://github.com/Shopify/liquid-c/pull/96