### PR TITLE
Add rubocop checks

### DIFF
--- a/.github/workflows/liquid.yml
+++ b/.github/workflows/liquid.yml
@@ -23,3 +23,4 @@ jobs:
       - run: bundle install --jobs=3 --retry=3 --path=vendor/bundle
       - run: bundle exec rake
         continue-on-error: ${{ matrix.entry.allowed-failure }}
+      - run: bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,13 @@
+inherit_gem:
+  rubocop-shopify: rubocop.yml
+
+require: rubocop-performance
+
+AllCops:
+  TargetRubyVersion: 2.5
+  Exclude:
+    - 'vendor/bundle/**/*'
+
+Style/GlobalVars:
+  Exclude:
+    - 'ext/liquid_c/extconf.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,14 @@
+# frozen_string_literal: true
 source 'https://rubygems.org'
 
 gemspec
 
 gem 'liquid', github: 'Shopify/liquid', ref: 'master'
 
-
 group :test do
+  gem 'rubocop', '~> 0.93.1', require: false
+  gem 'rubocop-performance', '~> 1.8.1', require: false
+  gem 'rubocop-shopify', '~> 1.0.6', require: false
   gem 'spy', '0.4.1'
   gem 'benchmark-ips'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rake'
 require 'rake/testtask'
 require 'bundler/gem_tasks'
@@ -9,7 +10,7 @@ ext_task = Rake::ExtensionTask.new("liquid_c")
 
 # For MacOS, generate debug information that ruby can read
 dsymutil = RbConfig::CONFIG['dsymutil']
-if !dsymutil.to_s.empty?
+unless dsymutil.to_s.empty?
   ext_lib_path = "lib/#{ext_task.binary}"
   dsym_path = "#{ext_lib_path}.dSYM"
 
@@ -19,19 +20,18 @@ if !dsymutil.to_s.empty?
   Rake::Task['compile'].enhance([dsym_path])
 end
 
+task default: :test
 
-task :default => :test
-
-task :test => ['test:unit', 'test:liquid']
+task test: ['test:unit', 'test:liquid']
 
 namespace :test do
-  Rake::TestTask.new(:unit => :compile) do |t|
+  Rake::TestTask.new(unit: :compile) do |t|
     t.libs << 'lib' << 'test'
     t.test_files = FileList['test/unit/**/*_test.rb']
   end
 
   desc 'run test suite with default parser'
-  Rake::TestTask.new(:base_liquid => :compile) do |t|
+  Rake::TestTask.new(base_liquid: :compile) do |t|
     t.libs << 'lib'
     t.test_files = ['test/liquid_test.rb']
   end

--- a/ext/liquid_c/extconf.rb
+++ b/ext/liquid_c/extconf.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mkmf'
 $CFLAGS << ' -std=c99 -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers'
 if RbConfig::CONFIG['host_os'] !~ /linux/ || Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7")
@@ -5,7 +6,7 @@ if RbConfig::CONFIG['host_os'] !~ /linux/ || Gem::Version.new(RUBY_VERSION) >= G
 end
 compiler = RbConfig::MAKEFILE_CONFIG['CC']
 if ENV['DEBUG'] == 'true'
-  if compiler =~ /gcc|g\+\+/
+  if /gcc|g\+\+/.match?(compiler)
     $CFLAGS << ' -fbounds-check'
   end
   CONFIG['optflags'] = ' -O0'
@@ -17,5 +18,5 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7.0") # added in 2.7
   $CFLAGS << ' -DHAVE_RB_HASH_BULK_INSERT'
 end
 
-$warnflags.gsub!(/-Wdeclaration-after-statement/, "") if $warnflags
+$warnflags&.gsub!(/-Wdeclaration-after-statement/, "")
 create_makefile("liquid_c")

--- a/liquid-c.gemspec
+++ b/liquid-c.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'liquid/c/version'
@@ -13,18 +14,18 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.extensions    = ['ext/liquid_c/extconf.rb']
-  spec.files         = `git ls-files -z`.split("\x0")
+  spec.files         = %x(git ls-files -z).split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.5.0"
 
-  spec.add_dependency 'liquid', '>= 3.0.0'
+  spec.add_dependency('liquid', '>= 3.0.0')
 
-  spec.add_development_dependency 'bundler', ">= 1.5" # has bugfix for segfaulting deploys
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency 'rake-compiler'
-  spec.add_development_dependency 'minitest'
-  spec.add_development_dependency 'stackprof' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.1.0")
+  spec.add_development_dependency('bundler', ">= 1.5") # has bugfix for segfaulting deploys
+  spec.add_development_dependency("rake")
+  spec.add_development_dependency('rake-compiler')
+  spec.add_development_dependency('minitest')
+  spec.add_development_dependency('stackprof') if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.1.0")
 end

--- a/performance.rb
+++ b/performance.rb
@@ -1,6 +1,7 @@
+# frozen_string_literal: true
 require 'liquid'
 require 'liquid/c' if ARGV.shift == "c"
-liquid_lib_dir = $LOAD_PATH.detect{ |p| File.exists?(File.join(p, 'liquid.rb')) }
+liquid_lib_dir = $LOAD_PATH.detect { |p| File.exist?(File.join(p, 'liquid.rb')) }
 
-script = ARGV.shift or abort("unspecified performance script")
+(script = ARGV.shift) || abort("unspecified performance script")
 require File.join(File.dirname(liquid_lib_dir), "performance/#{script}")

--- a/performance/c_profile.rb
+++ b/performance/c_profile.rb
@@ -2,7 +2,7 @@
 
 require 'liquid'
 require 'liquid/c'
-liquid_lib_dir = $LOAD_PATH.detect{ |p| File.exists?(File.join(p, 'liquid.rb')) }
+liquid_lib_dir = $LOAD_PATH.detect { |p| File.exist?(File.join(p, 'liquid.rb')) }
 require File.join(File.dirname(liquid_lib_dir), "performance/theme_runner")
 
 TASK_NAMES = %w(run compile render)
@@ -14,12 +14,10 @@ task = ThemeRunner.new.method(task_name)
 
 runner_id = fork do
   end_time = Time.now + 5.0
-  until Time.now >= end_time
-    task.call
-  end
+  task.call until Time.now >= end_time
 end
 
-profiler_pid = spawn "instruments -t 'Time Profiler' -p #{runner_id}"
+profiler_pid = spawn("instruments -t 'Time Profiler' -p #{runner_id}")
 
 Process.waitpid(runner_id)
 Process.waitpid(profiler_pid)

--- a/test/liquid_test.rb
+++ b/test/liquid_test.rb
@@ -1,4 +1,5 @@
-liquid_lib_dir = $LOAD_PATH.detect{ |p| File.exist?(File.join(p, 'liquid.rb')) }
+# frozen_string_literal: true
+liquid_lib_dir = $LOAD_PATH.detect { |p| File.exist?(File.join(p, 'liquid.rb')) }
 liquid_test_dir = File.join(File.dirname(liquid_lib_dir), 'test')
 $LOAD_PATH << liquid_test_dir
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 require 'minitest/autorun'
 require 'liquid/c'

--- a/test/unit/block_test.rb
+++ b/test/unit/block_test.rb
@@ -1,12 +1,13 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class BlockTest < MiniTest::Test
   def test_no_allocation_of_trimmed_strings
     template = Liquid::Template.parse("{{ a -}}     {{- b }}")
-    assert_equal 2, template.root.nodelist.size
+    assert_equal(2, template.root.nodelist.size)
 
     template = Liquid::Template.parse("{{ a -}} foo {{- b }}")
-    assert_equal 3, template.root.nodelist.size
+    assert_equal(3, template.root.nodelist.size)
   end
 
   def test_raise_on_output_with_non_utf8_encoding

--- a/test/unit/context_test.rb
+++ b/test/unit/context_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'bigdecimal'
 
@@ -6,28 +7,28 @@ class ContextTest < Minitest::Test
     context = Liquid::Context.new
 
     ["abc", 123, false, 1.21, BigDecimal(42)].each do |value|
-      assert_equal value, context.evaluate(value)
+      assert_equal(value, context.evaluate(value))
     end
 
-    assert_nil context.evaluate(nil)
+    assert_nil(context.evaluate(nil))
   end
 
   def test_evaluate_works_with_classes_that_have_an_evaluate_method
     class_with_evaluate = Class.new do
-      def evaluate(context)
+      def evaluate(_context)
         42
       end
     end
 
-    assert_equal 42, Liquid::Context.new.evaluate(class_with_evaluate.new)
+    assert_equal(42, Liquid::Context.new.evaluate(class_with_evaluate.new))
   end
 
   def test_evaluate_works_with_variable_lookup
-    assert_equal 42, Liquid::Context.new({"var" => 42}).evaluate(Liquid::C::Expression.strict_parse("var"))
+    assert_equal(42, Liquid::Context.new({ "var" => 42 }).evaluate(Liquid::C::Expression.strict_parse("var")))
   end
 
   def test_evaluating_a_variable_entirely_within_c
-    context = Liquid::Context.new({"var" => 42})
+    context = Liquid::Context.new({ "var" => 42 })
     lookup = Liquid::C::Expression.strict_parse("var")
     context.evaluate(lookup) # memoize vm_internal_new calls
 
@@ -49,16 +50,16 @@ class ContextTest < Minitest::Test
 
       context.evaluate(lookup)
     ensure
-      call_trace.disable if call_trace
-      c_call_trace.disable if c_call_trace
+      call_trace&.disable
+      c_call_trace&.disable
     end
 
-    assert_equal 0, called_ruby_method_count
-    assert_equal 1, called_c_method_count # context.evaluate call
+    assert_equal(0, called_ruby_method_count)
+    assert_equal(1, called_c_method_count) # context.evaluate call
   end
 
   class TestDrop < Liquid::Drop
-    def is_filtering
+    def is_filtering # rubocop:disable Naming/PredicateName
       @context.send(:c_filtering?)
     end
   end
@@ -67,7 +68,7 @@ class ContextTest < Minitest::Test
     context = Liquid::Context.new({ 'test' => [TestDrop.new] })
     template = Liquid::Template.parse('{{ test[0].is_filtering }},{{ test | map: "is_filtering" }}')
 
-    assert_equal "false,true", template.render!(context)
-    assert_equal false, context.send(:c_filtering?)
+    assert_equal("false,true", template.render!(context))
+    assert_equal(false, context.send(:c_filtering?))
   end
 end

--- a/test/unit/expression_test.rb
+++ b/test/unit/expression_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class ExpressionTest < MiniTest::Test
@@ -9,7 +10,7 @@ class ExpressionTest < MiniTest::Test
 
     empty = Liquid::C::Expression.strict_parse('empty')
     assert_equal('', empty)
-    assert_same empty, Liquid::C::Expression.strict_parse('blank')
+    assert_same(empty, Liquid::C::Expression.strict_parse('blank'))
   end
 
   def test_push_literals
@@ -57,7 +58,7 @@ class ExpressionTest < MiniTest::Test
   end
 
   def test_find_static_variable
-    context = Liquid::Context.new({"x" => 123})
+    context = Liquid::Context.new({ "x" => 123 })
     expr = Liquid::C::Expression.strict_parse('x')
 
     assert_instance_of(Liquid::C::Expression, expr)
@@ -65,7 +66,7 @@ class ExpressionTest < MiniTest::Test
   end
 
   def test_find_dynamic_variable
-    context = Liquid::Context.new({"x" => "y", "y" => 42})
+    context = Liquid::Context.new({ "x" => "y", "y" => 42 })
     expr = Liquid::C::Expression.strict_parse('[x]')
     assert_equal(42, context.evaluate(expr))
   end
@@ -84,7 +85,7 @@ class ExpressionTest < MiniTest::Test
   end
 
   def test_lookup_const_key
-    context = Liquid::Context.new({"obj" => { "prop" => "some value" }})
+    context = Liquid::Context.new({ "obj" => { "prop" => "some value" } })
 
     expr = Liquid::C::Expression.strict_parse('obj.prop')
     assert_equal('some value', context.evaluate(expr))
@@ -94,13 +95,13 @@ class ExpressionTest < MiniTest::Test
   end
 
   def test_lookup_variable_key
-    context = Liquid::Context.new({"field_name" => "prop", "obj" => { "prop" => "another value" }})
+    context = Liquid::Context.new({ "field_name" => "prop", "obj" => { "prop" => "another value" } })
     expr = Liquid::C::Expression.strict_parse('obj[field_name]')
     assert_equal('another value', context.evaluate(expr))
   end
 
   def test_lookup_command
-    context = Liquid::Context.new({"ary" => ['a', 'b', 'c']})
+    context = Liquid::Context.new({ "ary" => ['a', 'b', 'c'] })
     assert_equal(3, context.evaluate(Liquid::C::Expression.strict_parse('ary.size')))
     assert_equal('a', context.evaluate(Liquid::C::Expression.strict_parse('ary.first')))
     assert_equal('c', context.evaluate(Liquid::C::Expression.strict_parse('ary.last')))
@@ -131,7 +132,7 @@ class ExpressionTest < MiniTest::Test
   end
 
   def test_dynamic_range
-    context = Liquid::Context.new({"var" => 42})
+    context = Liquid::Context.new({ "var" => 42 })
     expr = Liquid::C::Expression.strict_parse('(1..var)')
     assert_instance_of(Liquid::C::Expression, expr)
     assert_equal((1..42), context.evaluate(expr))

--- a/test/unit/resource_limits_test.rb
+++ b/test/unit/resource_limits_test.rb
@@ -1,38 +1,39 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class ResourceLimitsTest < Minitest::Test
   def test_increment_render_score
     resource_limits = Liquid::ResourceLimits.new(render_score_limit: 5)
     resource_limits.increment_render_score(4)
-    assert_raises Liquid::MemoryError do
+    assert_raises(Liquid::MemoryError) do
       resource_limits.increment_render_score(2)
     end
-    assert_equal 6, resource_limits.render_score
+    assert_equal(6, resource_limits.render_score)
   end
 
   def test_increment_assign_score
     resource_limits = Liquid::ResourceLimits.new(assign_score_limit: 5)
     resource_limits.increment_assign_score(5)
-    assert_raises Liquid::MemoryError do
+    assert_raises(Liquid::MemoryError) do
       resource_limits.increment_assign_score(1)
     end
-    assert_equal 6, resource_limits.assign_score
+    assert_equal(6, resource_limits.assign_score)
   end
 
   def test_increment_write_score
     resource_limits = Liquid::ResourceLimits.new(render_length_limit: 5)
     output = 'a' * 10
-    assert_raises Liquid::MemoryError do
+    assert_raises(Liquid::MemoryError) do
       resource_limits.increment_write_score(output)
     end
   end
 
   def test_raise_limits_reached
     resource_limits = Liquid::ResourceLimits.new({})
-    assert_raises Liquid::MemoryError do
+    assert_raises(Liquid::MemoryError) do
       resource_limits.raise_limits_reached
     end
-    assert resource_limits.reached?
+    assert(resource_limits.reached?)
   end
 
   def test_with_capture
@@ -43,6 +44,6 @@ class ResourceLimitsTest < Minitest::Test
       resource_limits.increment_write_score(output)
     end
 
-    assert_equal 3, resource_limits.assign_score
+    assert_equal(3, resource_limits.assign_score)
   end
 end

--- a/test/unit/tokenizer_test.rb
+++ b/test/unit/tokenizer_test.rb
@@ -1,61 +1,62 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'test_helper'
 
 class TokenizerTest < Minitest::Test
   def test_tokenize_strings
-    assert_equal [' '], tokenize(' ')
-    assert_equal ['hello world'], tokenize('hello world')
+    assert_equal([' '], tokenize(' '))
+    assert_equal(['hello world'], tokenize('hello world'))
   end
 
   def test_tokenize_variables
-    assert_equal ['{{funk}}'], tokenize('{{funk}}')
-    assert_equal [' ', '{{funk}}', ' '], tokenize(' {{funk}} ')
-    assert_equal [' ', '{{funk}}', ' ', '{{so}}', ' ', '{{brother}}', ' '], tokenize(' {{funk}} {{so}} {{brother}} ')
-    assert_equal [' ', '{{  funk  }}', ' '], tokenize(' {{  funk  }} ')
+    assert_equal(['{{funk}}'], tokenize('{{funk}}'))
+    assert_equal([' ', '{{funk}}', ' '], tokenize(' {{funk}} '))
+    assert_equal([' ', '{{funk}}', ' ', '{{so}}', ' ', '{{brother}}', ' '], tokenize(' {{funk}} {{so}} {{brother}} '))
+    assert_equal([' ', '{{  funk  }}', ' '], tokenize(' {{  funk  }} '))
 
     # Doesn't strip whitespace
-    assert_equal [' ', '  funk  ', ' '], tokenize(' {{  funk  }} ', trimmed: true)
+    assert_equal([' ', '  funk  ', ' '], tokenize(' {{  funk  }} ', trimmed: true))
   end
 
   def test_tokenize_blocks
-    assert_equal ['{%comment%}'], tokenize('{%comment%}')
-    assert_equal [' ', '{%comment%}', ' '], tokenize(' {%comment%} ')
+    assert_equal(['{%comment%}'], tokenize('{%comment%}'))
+    assert_equal([' ', '{%comment%}', ' '], tokenize(' {%comment%} '))
 
-    assert_equal [' ', '{%comment%}', ' ', '{%endcomment%}', ' '], tokenize(' {%comment%} {%endcomment%} ')
-    assert_equal ['  ', '{% comment %}', ' ', '{% endcomment %}', ' '], tokenize("  {% comment %} {% endcomment %} ")
+    assert_equal([' ', '{%comment%}', ' ', '{%endcomment%}', ' '], tokenize(' {%comment%} {%endcomment%} '))
+    assert_equal(['  ', '{% comment %}', ' ', '{% endcomment %}', ' '], tokenize("  {% comment %} {% endcomment %} "))
 
     # Doesn't strip whitespace
-    assert_equal [' ', '  comment  ', ' '], tokenize(' {%  comment  %} ', trimmed: true)
+    assert_equal([' ', '  comment  ', ' '], tokenize(' {%  comment  %} ', trimmed: true))
   end
 
   def test_tokenize_for_liquid_tag
     source = "\nfunk\n\n  so | brother   \n"
 
-    assert_equal ["\nfunk\n\n  ", "so | brother   \n"], tokenize(source, for_liquid_tag: true)
+    assert_equal(["\nfunk\n\n  ", "so | brother   \n"], tokenize(source, for_liquid_tag: true))
 
     # Strips whitespace
-    assert_equal ["funk", "so | brother"], tokenize(source, for_liquid_tag: true, trimmed: true)
+    assert_equal(["funk", "so | brother"], tokenize(source, for_liquid_tag: true, trimmed: true))
   end
 
   def test_utf8_encoded_source
     source = 'auswählen'
-    assert_equal Encoding::UTF_8, source.encoding
+    assert_equal(Encoding::UTF_8, source.encoding)
     output = tokenize(source)
-    assert_equal [Encoding::UTF_8], output.map(&:encoding)
-    assert_equal [source], output
+    assert_equal([Encoding::UTF_8], output.map(&:encoding))
+    assert_equal([source], output)
   end
 
   def test_utf8_compatible_source
     source = String.new('ascii', encoding: Encoding::ASCII)
     tokenizer = Liquid::Tokenizer.new(source)
     output = tokenizer.shift
-    assert_equal Encoding::UTF_8, output.encoding
-    assert_equal source, output
+    assert_equal(Encoding::UTF_8, output.encoding)
+    assert_equal(source, output)
     assert_nil(tokenizer.shift)
   end
 
   def test_non_utf8_compatible_source
-    source = 'üñicode'.force_encoding(Encoding::BINARY)
+    source = 'üñicode'.dup.force_encoding(Encoding::BINARY)
     exc = assert_raises(Encoding::CompatibilityError) do
       Liquid::C::Tokenizer.new(source, 1, false)
     end
@@ -75,7 +76,7 @@ class TokenizerTest < Minitest::Test
   def tokenize(source, for_liquid_tag: false, trimmed: false)
     tokenizer = Liquid::C::Tokenizer.new(source, 1, for_liquid_tag)
     tokens = []
-    while t = (trimmed ? tokenizer.send(:shift_trimmed) : tokenizer.shift)
+    while (t = trimmed ? tokenizer.send(:shift_trimmed) : tokenizer.shift)
       tokens << t
     end
     tokens

--- a/test/unit/variable_test.rb
+++ b/test/unit/variable_test.rb
@@ -1,15 +1,16 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'test_helper'
 
 class VariableTest < Minitest::Test
   def test_variable_parse
-    assert_equal 'world', variable_strict_parse("hello").render!({ 'hello' => 'world' })
-    assert_equal 'world', variable_strict_parse('"world"').render!
-    assert_equal 'answer', variable_strict_parse('hello["world"]').render!({ 'hello' => { 'world' => "answer" } })
-    assert_equal 'answer', variable_strict_parse('question?').render!({ 'question?' => "answer" })
-    assert_equal 'value', variable_strict_parse('[meta]').render!({ 'meta' => 'key', 'key' => "value" })
-    assert_equal 'result', variable_strict_parse('a-b').render!({ 'a-b' => 'result' })
-    assert_equal 'result', variable_strict_parse('a-2').render!({ 'a-2' => 'result' })
+    assert_equal('world', variable_strict_parse("hello").render!({ 'hello' => 'world' }))
+    assert_equal('world', variable_strict_parse('"world"').render!)
+    assert_equal('answer', variable_strict_parse('hello["world"]').render!({ 'hello' => { 'world' => "answer" } }))
+    assert_equal('answer', variable_strict_parse('question?').render!({ 'question?' => "answer" }))
+    assert_equal('value', variable_strict_parse('[meta]').render!({ 'meta' => 'key', 'key' => "value" }))
+    assert_equal('result', variable_strict_parse('a-b').render!({ 'a-b' => 'result' }))
+    assert_equal('result', variable_strict_parse('a-2').render!({ 'a-2' => 'result' }))
   end
 
   def test_strictness
@@ -29,16 +30,16 @@ class VariableTest < Minitest::Test
   end
 
   def test_literals
-    assert_equal "", variable_strict_parse('').render!
-    assert_equal "true", variable_strict_parse('true').render!
-    assert_equal "", variable_strict_parse('nil').render!
-    assert_equal "123.4", variable_strict_parse('123.4').render!
+    assert_equal("", variable_strict_parse('').render!)
+    assert_equal("true", variable_strict_parse('true').render!)
+    assert_equal("", variable_strict_parse('nil').render!)
+    assert_equal("123.4", variable_strict_parse('123.4').render!)
 
-    assert_equal 'blank_value', variable_strict_parse('[blank]').render!({ '' => 'blank_value' })
-    assert_equal 'result', variable_strict_parse('[true][blank]').render!({ true => { '' => 'result' } })
-    assert_equal 'result', variable_strict_parse('x["size"]').render!({ 'x' => { 'size' => 'result' } })
-    assert_equal 'result', variable_strict_parse('blank.x').render!({ 'blank' => { 'x' => 'result' } })
-    assert_equal 'result', variable_strict_parse('blank["x"]').render!({ 'blank' => { 'x' => 'result' } })
+    assert_equal('blank_value', variable_strict_parse('[blank]').render!({ '' => 'blank_value' }))
+    assert_equal('result', variable_strict_parse('[true][blank]').render!({ true => { '' => 'result' } }))
+    assert_equal('result', variable_strict_parse('x["size"]').render!({ 'x' => { 'size' => 'result' } }))
+    assert_equal('result', variable_strict_parse('blank.x').render!({ 'blank' => { 'x' => 'result' } }))
+    assert_equal('result', variable_strict_parse('blank["x"]').render!({ 'blank' => { 'x' => 'result' } }))
   end
 
   module InspectCallFilters
@@ -61,10 +62,10 @@ class VariableTest < Minitest::Test
     context = { 'name' => 'Bob' }
 
     filter1_output = variable_strict_parse('name | filter1').render!(context, filters: [InspectCallFilters])
-    assert_equal '{ filter: :filter1, input: "Bob", args: [] }', filter1_output
+    assert_equal('{ filter: :filter1, input: "Bob", args: [] }', filter1_output)
 
     filter2_output = variable_strict_parse('name | filter1 | filter2').render!(context, filters: [InspectCallFilters])
-    assert_equal "{ filter: :filter2, input: #{filter1_output.inspect}, args: [] }", filter2_output
+    assert_equal("{ filter: :filter2, input: #{filter1_output.inspect}, args: [] }", filter2_output)
   end
 
   def test_variable_filter_args
@@ -72,65 +73,65 @@ class VariableTest < Minitest::Test
     render_opts = { filters: [InspectCallFilters] }
 
     filter1_output = variable_strict_parse('name | filter1: abc').render!(context, render_opts)
-    assert_equal '{ filter: :filter1, input: "Bob", args: ["xyz"] }', filter1_output
+    assert_equal('{ filter: :filter1, input: "Bob", args: ["xyz"] }', filter1_output)
 
     filter2_output = variable_strict_parse('name | filter1: abc | filter2: abc').render!(context, render_opts)
-    assert_equal "{ filter: :filter2, input: #{filter1_output.inspect}, args: [\"xyz\"] }", filter2_output
+    assert_equal("{ filter: :filter2, input: #{filter1_output.inspect}, args: [\"xyz\"] }", filter2_output)
 
     context = { 'name' => 'Bob', 'a' => 1, 'c' => 3, 'e' => 5 }
 
     output = variable_strict_parse('name | filter1 : a , b : c , d : e').render!(context, render_opts)
-    assert_equal '{ filter: :filter1, input: "Bob", args: [1, {"b"=>3, "d"=>5}] }', output
+    assert_equal('{ filter: :filter1, input: "Bob", args: [1, {"b"=>3, "d"=>5}] }', output)
 
-    assert_raises Liquid::SyntaxError do
+    assert_raises(Liquid::SyntaxError) do
       variable_strict_parse('name | filter : a : b : c : d : e')
     end
   end
 
   def test_unicode_strings
     string_content = 'å߀êùｉｄｈｔлｓԁѵ߀ｒáƙìｓｔɦｅƅêｓｔｐｃｍáѕｔｅｒｒãｃêｃհèｒｒ'
-    assert_equal string_content, variable_strict_parse("\"#{string_content}\"").render!
+    assert_equal(string_content, variable_strict_parse("\"#{string_content}\"").render!)
   end
 
   def test_broken_unicode_errors
     err = assert_raises(Liquid::SyntaxError) do
       Liquid::Template.parse("test {{ \xC2\xA0 test }}", error_mode: :strict)
     end
-    assert err.message
+    assert(err.message)
   end
 
   def test_callbacks
     variable_fallbacks = 0
 
     callbacks = {
-      variable_fallback: lambda { variable_fallbacks += 1 }
+      variable_fallback: lambda { variable_fallbacks += 1 },
     }
 
     Liquid::Template.parse('{{abc}}', error_mode: :lax, stats_callbacks: callbacks)
-    assert_equal 0, variable_fallbacks
+    assert_equal(0, variable_fallbacks)
 
     Liquid::Template.parse('{{@!#}}', error_mode: :lax, stats_callbacks: callbacks)
-    assert_equal 1, variable_fallbacks
+    assert_equal(1, variable_fallbacks)
   end
 
   def test_write_string
     output = Liquid::Template.parse("{{ str }}").render({ 'str' => 'foo' })
-    assert_equal "foo", output
+    assert_equal("foo", output)
   end
 
   def test_write_fixnum
     output = Liquid::Template.parse("{{ num }}").render({ 'num' => 123456 })
-    assert_equal "123456", output
+    assert_equal("123456", output)
   end
 
   def test_write_array
     output = Liquid::Template.parse("{{ ary }}").render({ 'ary' => ['foo', 123, ['nested', 'ary'], nil, 0.5] })
-    assert_equal "foo123nestedary0.5", output
+    assert_equal("foo123nestedary0.5", output)
   end
 
   def test_write_nil
     output = Liquid::Template.parse("{{ obj }}").render({ 'obj' => nil })
-    assert_equal "", output
+    assert_equal("", output)
   end
 
   class StringConvertible
@@ -149,7 +150,7 @@ class VariableTest < Minitest::Test
 
   def test_write_to_s_convertible_object
     output = Liquid::Template.parse("{{ obj }}").render!({ 'obj' => StringConvertible.new('foo') })
-    assert_equal "foo", output
+    assert_equal("foo", output)
   end
 
   def test_write_object_with_broken_to_s
@@ -157,7 +158,10 @@ class VariableTest < Minitest::Test
     exc = assert_raises(TypeError) do
       template.render!({ 'obj' => StringConvertible.new(123) })
     end
-    assert_equal("VariableTest::StringConvertible#to_s returned a non-String convertible value of type Integer", exc.message)
+    assert_equal(
+      "VariableTest::StringConvertible#to_s returned a non-String convertible value of type Integer",
+      exc.message
+    )
   end
 
   class DerivedString < String
@@ -168,47 +172,47 @@ class VariableTest < Minitest::Test
 
   def test_write_derived_string
     output = Liquid::Template.parse("{{ obj }}").render!({ 'obj' => DerivedString.new('bar') })
-    assert_equal "bar", output
+    assert_equal("bar", output)
   end
 
   def test_filter_without_args
     output = Liquid::Template.parse("{{ var | upcase }}").render({ 'var' => 'Hello' })
-    assert_equal "HELLO", output
+    assert_equal("HELLO", output)
   end
 
   def test_filter_with_const_arg
     output = Liquid::Template.parse("{{ x | plus: 2 }}").render({ 'x' => 3 })
-    assert_equal "5", output
+    assert_equal("5", output)
   end
 
   def test_filter_with_variable_arg
     output = Liquid::Template.parse("{{ x | plus: y }}").render({ 'x' => 10, 'y' => 123 })
-    assert_equal "133", output
+    assert_equal("133", output)
   end
 
   def test_filter_with_variable_arg_after_const_arg
     output = Liquid::Template.parse("{{ ary | slice: 1, 2 }}").render({ 'ary' => [1, 2, 3, 4] })
-    assert_equal "23", output
+    assert_equal("23", output)
   end
 
   def test_filter_with_const_keyword_arg
     output = Liquid::Template.parse("{{ value | default: 'None' }}").render({ 'value' => false })
-    assert_equal 'None', output
+    assert_equal('None', output)
 
     output = Liquid::Template.parse("{{ value | default: 'None', allow_false: true }}").render({ 'value' => false })
-    assert_equal 'false', output
+    assert_equal('false', output)
   end
 
   def test_filter_with_variable_keyword_arg
     template = Liquid::Template.parse("{{ value | default: 'None', allow_false: false_allowed }}")
 
-    assert_equal 'None', template.render({ 'value' => false, 'false_allowed' => false })
-    assert_equal 'false', template.render({ 'value' => false, 'false_allowed' => true })
+    assert_equal('None', template.render({ 'value' => false, 'false_allowed' => false }))
+    assert_equal('false', template.render({ 'value' => false, 'false_allowed' => true }))
   end
 
   def test_filter_error
     output = Liquid::Template.parse("before ({{ ary | concat: 2 }}) after").render({ 'ary' => [1] })
-    assert_equal 'before (Liquid error: concat filter requires an array argument) after', output
+    assert_equal('before (Liquid error: concat filter requires an array argument) after', output)
   end
 
   private


### PR DESCRIPTION
Adds rubocop checks. Uses the defaults in [Shopify/ruby-style-guide](https://github.com/Shopify/ruby-style-guide). Most of the changes were autocorrected by rubocop.