### PR TITLE
Allow up to 32-bits for source file size

### DIFF
--- a/ext/liquid_c/tokenizer.c
+++ b/ext/liquid_c/tokenizer.c
@@ -47,9 +47,9 @@ static VALUE tokenizer_initialize_method(VALUE self, VALUE source, VALUE start_l
     Check_Type(source, T_STRING);
     check_utf8_encoding(source, "source");
 
-#define MAX_SOURCE_CODE_BYTES ((1 << 24) - 1)
+#define MAX_SOURCE_CODE_BYTES ((1L << 32) - 1)
     if (RSTRING_LEN(source) > MAX_SOURCE_CODE_BYTES) {
-        rb_enc_raise(utf8_encoding, rb_eArgError, "Source too large, max %d bytes", MAX_SOURCE_CODE_BYTES);
+        rb_enc_raise(utf8_encoding, rb_eArgError, "Source too large, max %ld bytes", MAX_SOURCE_CODE_BYTES);
     }
 #undef MAX_SOURCE_CODE_BYTES
 

--- a/ext/liquid_c/vm_assembler.c
+++ b/ext/liquid_c/vm_assembler.c
@@ -47,7 +47,7 @@ void vm_assembler_gc_mark(vm_assembler_t *code)
                 break;
 
             case OP_RENDER_VARIABLE_RESCUE:
-                ip += 3;
+                ip += sizeof(uint32_t);
                 break;
 
             case OP_WRITE_RAW:

--- a/ext/liquid_c/vm_assembler.h
+++ b/ext/liquid_c/vm_assembler.h
@@ -204,10 +204,10 @@ static inline void vm_assembler_add_filter(vm_assembler_t *code, VALUE filter_na
     c_buffer_write(&code->instructions, &instructions, 2);
 }
 
-static inline void vm_assembler_add_render_variable_rescue(vm_assembler_t *code, size_t node_line_number)
+static inline void vm_assembler_add_render_variable_rescue(vm_assembler_t *code, uint32_t node_line_number)
 {
-    uint8_t instructions[4] = { OP_RENDER_VARIABLE_RESCUE, node_line_number >> 16, node_line_number >> 8, node_line_number };
-    c_buffer_write(&code->instructions, &instructions, sizeof(instructions));
+    vm_assembler_write_opcode(code, OP_RENDER_VARIABLE_RESCUE);
+    c_buffer_write(&code->instructions, &node_line_number, sizeof(uint32_t));
 }
 
 #endif

--- a/test/unit/tokenizer_test.rb
+++ b/test/unit/tokenizer_test.rb
@@ -65,7 +65,7 @@ class TokenizerTest < Minitest::Test
 
   def test_source_too_large
     err = assert_raises(ArgumentError) do
-      tokenize("a" * 2**24)
+      tokenize("a" * 2**32)
     end
 
     assert_match(/Source too large, max \d+ bytes/, err.message)


### PR DESCRIPTION
#81 introduced a restriction that enforces source files to be 24-bits in length (16MiB). This doesn't seem to be enough sometimes. This PR changes the restrictions to be 32-bits in length (4GiB) which should be enough.