### PR TITLE
Fallback to not using the liquid VM if the source is too large

### DIFF
--- a/test/unit/tokenizer_test.rb
+++ b/test/unit/tokenizer_test.rb
@@ -85,7 +85,7 @@ class TokenizerTest < Minitest::Test
     Liquid::Document.parse(liquid_c_tokenizer, parse_context)
     refute(parse_context.send(:disable_liquid_c_nodes))
     Liquid::Document.parse(fallback_tokenizer, parse_context)
-    assert(true, parse_context.send(:disable_liquid_c_nodes))
+    assert_equal(true, parse_context.send(:disable_liquid_c_nodes))
   end
 
   private


### PR DESCRIPTION
## Problem

It turns out that we do have usage of liquid with a larger than 24-bit length source strings.

We could workaround this in the application by using the `disable_liquid_c_nodes` parse option.  However, it doesn't seem like the application should have to be aware of this limit.

## Solution

Add a fallback in the ruby patch for Liquid::Tokenizer.new to the ruby tokenizer if the source is too large to use the liquid-c tokenizer.  We want to propagate this to the Liquid::ParseContext, so I did this in a Liquid::Document.parse method wrapper.