### PR TITLE
Run rubocop in the default rake task to help notice style errors before CI

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,7 @@ unless dsymutil.to_s.empty?
   Rake::Task['compile'].enhance([dsym_path])
 end
 
-task default: :test
+task default: [:test, :rubocop]
 
 task test: ['test:unit', 'test:liquid']
 
@@ -44,6 +44,11 @@ namespace :test do
     Rake::Task['test:base_liquid'].reenable
     Rake::Task['test:base_liquid'].invoke
   end
+end
+
+task :rubocop do
+  require 'rubocop/rake_task'
+  RuboCop::RakeTask.new
 end
 
 namespace :benchmark do


### PR DESCRIPTION
## Problem

Before pushing changes to open a pull request, I often use the default rake task to make sure the tests pass on the version of ruby I'm developing with.  However, I just pushed and noticed a CI failure and only then realized that there were rubocop errors.  Ideally, I would notice these locally before pushing changes.

## Solution

I copied the rubocop rake task from the liquid gem and similarly added it to the default rake task.