### PR TITLE
Fix Liquid::C::BlockBody#nodelist after freeze

### DIFF
--- a/ext/liquid_c/block.c
+++ b/ext/liquid_c/block.c
@@ -69,6 +69,7 @@ static VALUE block_body_allocate(VALUE klass)
     body->source = Qnil;
     body->render_score = 0;
     body->blank = true;
+    body->nodelist = Qundef;
     return obj;
 }
 
@@ -304,12 +305,10 @@ static VALUE block_body_nodelist(VALUE self)
     ensure_not_parsing(body);
     memoize_variable_placeholder();
 
-    // Use rb_attr_get insteaad of rb_ivar_get to avoid an instance variable not
-    // initialized warning.
-    VALUE nodelist = rb_attr_get(self, intern_ivar_nodelist);
-    if (nodelist != Qnil)
-        return nodelist;
-    nodelist = rb_ary_new_capa(body->render_score);
+    if (body->nodelist != Qundef)
+        return body->nodelist;
+
+    VALUE nodelist = rb_ary_new_capa(body->render_score);
 
     const size_t *const_ptr = (size_t *)body->code.constants.data;
     const uint8_t *ip = body->code.instructions.data;
@@ -340,7 +339,7 @@ static VALUE block_body_nodelist(VALUE self)
 loop_break:
 
     rb_ary_freeze(nodelist);
-    rb_ivar_set(self, intern_ivar_nodelist, nodelist);
+    body->nodelist = nodelist;
     return nodelist;
 }
 

--- a/ext/liquid_c/block.h
+++ b/ext/liquid_c/block.h
@@ -9,6 +9,7 @@ typedef struct block_body {
     VALUE source; // hold a reference to the ruby object that OP_WRITE_RAW points to
     bool blank;
     int render_score;
+    VALUE nodelist;
 } block_body_t;
 
 void init_liquid_block();


### PR DESCRIPTION
## Problem

https://github.com/Shopify/liquid/pull/1331 introduced a unit test failure in liquid-c's test suite:

```
  1) Error:
BlockTest#test_no_allocation_of_trimmed_strings:
FrozenError: can't modify frozen Liquid::C::BlockBody: #<Liquid::C::BlockBody:0x00007f83f0859618>
    /Users/dylants/.gem/ruby/2.7.2/bundler/gems/liquid-61d54d1b190a/lib/liquid/document.rb:19:in `nodelist'
    /Users/dylants/.gem/ruby/2.7.2/bundler/gems/liquid-61d54d1b190a/lib/liquid/document.rb:19:in `nodelist'
    /Users/dylants/src/liquid-c/test/unit/block_test.rb:7:in `test_no_allocation_of_trimmed_strings'
```

which is happening the nodelist was being memoized using an instance variable (to avoid using extra storage space when it isn't used)

## Solution

Move the nodelist into a field in the C struct, so that it can be modified even after the block body is frozen.