### PR TITLE
Fix parsing nil

### DIFF
--- a/lib/liquid/c.rb
+++ b/lib/liquid/c.rb
@@ -43,8 +43,9 @@ end
 
 Liquid::Tokenizer.class_eval do
   def self.new(source, line_numbers = false, line_number: nil, for_liquid_tag: false)
+    source = source.to_s
     if Liquid::C.enabled && source.bytesize <= Liquid::C::Tokenizer::MAX_SOURCE_BYTE_SIZE
-      source = source.to_s.encode(Encoding::UTF_8)
+      source = source.encode(Encoding::UTF_8)
       Liquid::C::Tokenizer.new(source, line_number || (line_numbers ? 1 : 0), for_liquid_tag)
     else
       super

--- a/test/unit/tokenizer_test.rb
+++ b/test/unit/tokenizer_test.rb
@@ -3,6 +3,11 @@
 require 'test_helper'
 
 class TokenizerTest < Minitest::Test
+  def test_tokenizer_nil
+    tokenizer = Liquid::Tokenizer.new(nil)
+    assert_nil(tokenizer.shift)
+  end
+
   def test_tokenize_strings
     assert_equal([' '], tokenize(' '))
     assert_equal(['hello world'], tokenize('hello world'))


### PR DESCRIPTION
## Problem

I tried using https://github.com/Shopify/liquid-c/pull/104 in Shopify and got the following CI failure

```
NoMethodError: undefined method `bytesize' for nil:NilClass
	/tmp/bundle/ruby/2.7.0/bundler/gems/liquid-c-9f60b48ea895/lib/liquid/c.rb:46:in `new'
```

which was happening because the test was trying to parse a `nil` template source, but https://github.com/Shopify/liquid-c/pull/104 introduced a call to `bytesize` on the source *before* it was actually coerced to a string.

## Solution

Coerce to a string before calling `bytesize`