### PR TITLE
Run CI on PRs

### DIFF
--- a/.github/workflows/liquid.yml
+++ b/.github/workflows/liquid.yml
@@ -1,5 +1,5 @@
 name: Liquid
-on: [push]
+on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Issue came up in Shopify/liquid#1336 where CI is not ran on PRs from forks, so change it here too.
