### PR TITLE
Add disassemble method to Liquid::C::BlockBody and Liquid::C::Expression

### DIFF
--- a/ext/liquid_c/block.c
+++ b/ext/liquid_c/block.c
@@ -343,6 +343,14 @@ loop_break:
     return nodelist;
 }
 
+static VALUE block_body_disassemble(VALUE self)
+{
+    block_body_t *body;
+    BlockBody_Get_Struct(self, body);
+    return vm_assembler_disassemble(&body->code);
+}
+
+
 static VALUE block_body_add_evaluate_expression(VALUE self, VALUE expression)
 {
     block_body_t *body;
@@ -421,6 +429,7 @@ void init_liquid_block()
     rb_define_method(cLiquidCBlockBody, "remove_blank_strings", block_body_remove_blank_strings, 0);
     rb_define_method(cLiquidCBlockBody, "blank?", block_body_blank_p, 0);
     rb_define_method(cLiquidCBlockBody, "nodelist", block_body_nodelist, 0);
+    rb_define_method(cLiquidCBlockBody, "disassemble", block_body_disassemble, 0);
 
     rb_define_method(cLiquidCBlockBody, "add_evaluate_expression", block_body_add_evaluate_expression, 1);
     rb_define_method(cLiquidCBlockBody, "add_find_variable", block_body_add_find_variable, 1);

--- a/ext/liquid_c/expression.c
+++ b/ext/liquid_c/expression.c
@@ -89,10 +89,18 @@ VALUE internal_expression_evaluate(expression_t *expression, VALUE context)
     return liquid_vm_evaluate(context, &expression->code);
 }
 
+static VALUE expression_disassemble(VALUE self)
+{
+    expression_t *expression;
+    Expression_Get_Struct(self, expression);
+    return vm_assembler_disassemble(&expression->code);
+}
+
 void init_liquid_expression()
 {
     cLiquidCExpression = rb_define_class_under(mLiquidC, "Expression", rb_cObject);
     rb_undef_alloc_func(cLiquidCExpression);
     rb_define_singleton_method(cLiquidCExpression, "strict_parse", expression_strict_parse, 1);
     rb_define_method(cLiquidCExpression, "evaluate", expression_evaluate, 1);
+    rb_define_method(cLiquidCExpression, "disassemble", expression_disassemble, 0);
 }

--- a/ext/liquid_c/vm.c
+++ b/ext/liquid_c/vm.c
@@ -474,11 +474,6 @@ typedef struct vm_render_rescue_args {
     size_t old_stack_byte_size;
 } vm_render_rescue_args_t;
 
-static inline unsigned int decode_node_line_number(const uint8_t *node_line_number)
-{
-    return (node_line_number[0] << 16) | (node_line_number[1] << 8) | node_line_number[2];
-}
-
 // Actually returns a bool resume_rendering value
 static VALUE vm_render_rescue(VALUE uncast_args, VALUE exception)
 {

--- a/ext/liquid_c/vm.h
+++ b/ext/liquid_c/vm.h
@@ -10,4 +10,9 @@ void liquid_vm_next_instruction(const uint8_t **ip_ptr, const size_t **const_ptr
 bool liquid_vm_filtering(VALUE context);
 VALUE liquid_vm_evaluate(VALUE context, vm_assembler_t *code);
 
+static inline unsigned int decode_node_line_number(const uint8_t *node_line_number)
+{
+    return (node_line_number[0] << 16) | (node_line_number[1] << 8) | node_line_number[2];
+}
+
 #endif

--- a/ext/liquid_c/vm_assembler.c
+++ b/ext/liquid_c/vm_assembler.c
@@ -126,8 +126,7 @@ VALUE vm_assembler_disassemble(vm_assembler_t *code)
 
             case OP_PUSH_INT16:
             {
-                int num = *(int8_t *)ip++;
-                num = (num << 8) | ip[1];
+                int num = (ip[1] << 8) | ip[2];
                 rb_str_catf(output, "push_int16(%u)\n", num);
                 break;
             }

--- a/ext/liquid_c/vm_assembler.c
+++ b/ext/liquid_c/vm_assembler.c
@@ -172,7 +172,7 @@ VALUE vm_assembler_disassemble(vm_assembler_t *code)
                 break;
 
             default:
-                rb_str_catf(output, "<%d>\n", ip[0]);
+                rb_str_catf(output, "<opcode number %d disassembly not implemented>\n", ip[0]);
                 break;
         }
         liquid_vm_next_instruction(&ip, &const_ptr);

--- a/ext/liquid_c/vm_assembler.c
+++ b/ext/liquid_c/vm_assembler.c
@@ -1,6 +1,7 @@
 #include "liquid.h"
 #include "vm_assembler.h"
 #include "expression.h"
+#include "vm.h"
 
 void vm_assembler_init(vm_assembler_t *code)
 {
@@ -71,6 +72,113 @@ void vm_assembler_gc_mark(vm_assembler_t *code)
                 rb_bug("invalid opcode: %u", ip[-1]);
         }
     }
+}
+
+VALUE vm_assembler_disassemble(vm_assembler_t *code)
+{
+    const size_t *const_ptr = (size_t *)code->constants.data;
+    const uint8_t *start_ip = code->instructions.data;
+    const uint8_t *ip = start_ip;
+    const uint8_t *end_ip = code->instructions.data_end;
+    VALUE output = rb_str_buf_new(32);
+    while (ip < end_ip) {
+        rb_str_catf(output, "0x%04lx: ", ip - start_ip);
+        switch (*ip) {
+            case OP_LEAVE:
+                rb_str_catf(output, "leave\n");
+                break;
+
+            case OP_POP_WRITE:
+                rb_str_catf(output, "pop_write\n");
+                break;
+
+            case OP_PUSH_NIL:
+                rb_str_catf(output, "push_nil\n");
+                break;
+
+            case OP_PUSH_TRUE:
+                rb_str_catf(output, "push_true\n");
+                break;
+
+            case OP_PUSH_FALSE:
+                rb_str_catf(output, "push_false\n");
+                break;
+
+            case OP_FIND_VAR:
+                rb_str_catf(output, "find_var\n");
+                break;
+
+            case OP_LOOKUP_KEY:
+                rb_str_catf(output, "lookup_key\n");
+                break;
+
+            case OP_NEW_INT_RANGE:
+                rb_str_catf(output, "new_int_range\n");
+                break;
+
+            case OP_HASH_NEW:
+                rb_str_catf(output, "hash_new(%u)\n", ip[1]);
+                break;
+
+            case OP_PUSH_INT8:
+                rb_str_catf(output, "push_int8(%u)\n", ip[1]);
+                break;
+
+            case OP_PUSH_INT16:
+            {
+                int num = *(int8_t *)ip++;
+                num = (num << 8) | ip[1];
+                rb_str_catf(output, "push_int16(%u)\n", num);
+                break;
+            }
+
+            case OP_RENDER_VARIABLE_RESCUE:
+            {
+                unsigned int line_number = decode_node_line_number(ip + 1);
+                rb_str_catf(output, "render_variable_rescue(line_number: %u)\n", line_number);
+                break;
+            }
+
+            case OP_WRITE_RAW:
+            {
+                const char *text = (const char *)const_ptr[0];
+                size_t size = const_ptr[1];
+                VALUE string = rb_enc_str_new(text, size, utf8_encoding);
+                rb_str_catf(output, "write_raw(%+"PRIsVALUE")\n", string);
+                break;
+            }
+
+            case OP_WRITE_NODE:
+                rb_str_catf(output, "write_node(%+"PRIsVALUE")\n", const_ptr[0]);
+                break;
+
+            case OP_PUSH_CONST:
+                rb_str_catf(output, "push_const(%+"PRIsVALUE")\n", const_ptr[0]);
+                break;
+
+            case OP_FIND_STATIC_VAR:
+                rb_str_catf(output, "find_static_var(%+"PRIsVALUE")\n", const_ptr[0]);
+                break;
+
+            case OP_LOOKUP_CONST_KEY:
+                rb_str_catf(output, "lookup_const_key(%+"PRIsVALUE")\n", const_ptr[0]);
+                break;
+
+            case OP_LOOKUP_COMMAND:
+                rb_str_catf(output, "lookup_command(%+"PRIsVALUE")\n", const_ptr[0]);
+                break;
+
+            case OP_FILTER:
+                rb_str_catf(output, "filter(name: %+"PRIsVALUE", num_args: %u)\n", const_ptr[0], ip[1]);
+                break;
+
+            default:
+                rb_str_catf(output, "<%d>\n", ip[0]);
+                break;
+        }
+        liquid_vm_next_instruction(&ip, &const_ptr);
+    }
+    return output;
 }
 
 void vm_assembler_concat(vm_assembler_t *dest, vm_assembler_t *src)

--- a/ext/liquid_c/vm_assembler.h
+++ b/ext/liquid_c/vm_assembler.h
@@ -40,6 +40,7 @@ void init_liquid_vm_assembler();
 void vm_assembler_init(vm_assembler_t *code);
 void vm_assembler_free(vm_assembler_t *code);
 void vm_assembler_gc_mark(vm_assembler_t *code);
+VALUE vm_assembler_disassemble(vm_assembler_t *code);
 void vm_assembler_concat(vm_assembler_t *dest, vm_assembler_t *src);
 void vm_assembler_require_stack_args(vm_assembler_t *code, unsigned int count);
 

--- a/test/unit/block_test.rb
+++ b/test/unit/block_test.rb
@@ -24,4 +24,29 @@ class BlockTest < MiniTest::Test
     template = Liquid::Template.parse("ü{{ unicode_char }}")
     assert_equal("üñ", template.render!({ 'unicode_char' => 'ñ' }, output: output))
   end
+
+  def test_disassemble
+    source = <<~LIQUID
+      raw
+      {{- var | default: "none", allow_false: true -}}
+      {%- increment counter -%}
+    LIQUID
+    template = Liquid::Template.parse(source, line_numbers: true)
+    block_body = template.root.body
+    increment_node = block_body.nodelist[2]
+    assert_instance_of(Liquid::Increment, increment_node)
+    assert_equal(<<~ASM, block_body.disassemble)
+      0x0000: write_raw("raw")
+      0x0001: render_variable_rescue(line_number: 2)
+      0x0005: find_static_var("var")
+      0x0006: push_const("none")
+      0x0007: push_const("allow_false")
+      0x0008: push_true
+      0x0009: hash_new(1)
+      0x000b: filter(name: :default, num_args: 3)
+      0x000d: pop_write
+      0x000e: write_node(#{increment_node.inspect})
+      0x000f: leave
+    ASM
+  end
 end

--- a/test/unit/expression_test.rb
+++ b/test/unit/expression_test.rb
@@ -149,6 +149,14 @@ class ExpressionTest < MiniTest::Test
     ASM
   end
 
+  def test_disassemble_int16
+    assert_equal(<<~ASM, Liquid::C::Expression.strict_parse('[12345]').disassemble)
+      0x0000: push_int16(12345)
+      0x0003: find_var
+      0x0004: leave
+    ASM
+  end
+
   private
 
   class ReturnKeyDrop < Liquid::Drop

--- a/test/unit/expression_test.rb
+++ b/test/unit/expression_test.rb
@@ -138,6 +138,17 @@ class ExpressionTest < MiniTest::Test
     assert_equal((1..42), context.evaluate(expr))
   end
 
+  def test_disassemble
+    expression = Liquid::C::Expression.strict_parse('foo.bar[123]')
+    assert_equal(<<~ASM, expression.disassemble)
+      0x0000: find_static_var("foo")
+      0x0001: lookup_const_key("bar")
+      0x0002: push_int8(123)
+      0x0004: lookup_key
+      0x0005: leave
+    ASM
+  end
+
   private
 
   class ReturnKeyDrop < Liquid::Drop


### PR DESCRIPTION
## Problem

After compilation, Liquid::C::BlockBody and Liquid::C::Expression objects are completely opaque.  This makes it hard to inspect the state of these objects for debugging or to test compilation to specialized instructions when a more general one would have the same semantics.

## Solution

Add disassemble methods that return a string that can be printed with `puts` for debugging (e.g. `puts template.root.body.disassemble`) or used as a test assertion as the included unit tests demonstrate.