### PR TITLE
Strict parse Liquid::Variable.new objects to a Liquid::C::Expression

### DIFF
--- a/ext/liquid_c/block.c
+++ b/ext/liquid_c/block.c
@@ -142,7 +142,8 @@ static tag_markup_t internal_block_body_parse(block_body_t *body, parse_context_
                 variable_parse_args_t parse_args = {
                     .markup = token.str_trimmed,
                     .markup_end = token.str_trimmed + token.len_trimmed,
-                    .body = body,
+                    .code = &body->code,
+                    .code_obj = body->obj,
                     .parse_context = parse_context->ruby_obj,
                 };
                 internal_variable_compile(&parse_args, token_start_line_number);

--- a/ext/liquid_c/block.c
+++ b/ext/liquid_c/block.c
@@ -144,9 +144,8 @@ static tag_markup_t internal_block_body_parse(block_body_t *body, parse_context_
                     .markup_end = token.str_trimmed + token.len_trimmed,
                     .body = body,
                     .parse_context = parse_context->ruby_obj,
-                    .line_number = token_start_line_number,
                 };
-                internal_variable_parse(&parse_args);
+                internal_variable_compile(&parse_args, token_start_line_number);
                 render_score_increment += 1;
                 body->blank = false;
                 break;

--- a/ext/liquid_c/variable.h
+++ b/ext/liquid_c/variable.h
@@ -9,11 +9,11 @@ typedef struct variable_parse_args {
     const char *markup_end;
     block_body_t *body;
     VALUE parse_context;
-    unsigned int line_number;
 } variable_parse_args_t;
 
 void init_liquid_variable(void);
-void internal_variable_parse(variable_parse_args_t *parse_args);
+void internal_variable_compile(variable_parse_args_t *parse_args, unsigned int line_number);
+void internal_variable_compile_evaluate(variable_parse_args_t *parse_args);
 
 #endif
 

--- a/ext/liquid_c/variable.h
+++ b/ext/liquid_c/variable.h
@@ -7,7 +7,8 @@
 typedef struct variable_parse_args {
     const char *markup;
     const char *markup_end;
-    block_body_t *body;
+    vm_assembler_t *code;
+    VALUE code_obj;
     VALUE parse_context;
 } variable_parse_args_t;
 

--- a/lib/liquid/c.rb
+++ b/lib/liquid/c.rb
@@ -68,8 +68,7 @@ Liquid::ParseContext.class_eval do
     end
   end
 
-  private
-
+  # @api private
   def disable_liquid_c_nodes
     # Liquid::Profiler exposes the internal parse tree that we don't want to build when
     # parsing with liquid-c, so consider liquid-c to be disabled when using it.
@@ -138,6 +137,16 @@ Liquid::Variable.class_eval do
 
     def set_error_mode(parse_context, mode)
       parse_context.instance_variable_set(:@error_mode, mode)
+    end
+  end
+
+  alias_method :ruby_strict_parse, :strict_parse
+
+  def strict_parse(markup)
+    if parse_context.disable_liquid_c_nodes
+      ruby_strict_parse(markup)
+    else
+      c_strict_parse(markup)
     end
   end
 end


### PR DESCRIPTION
This solves the problem that https://github.com/Shopify/liquid-c/pull/96 intended to solve in a simpler way, so that PR can be focused on introducing support for compiling tags to VM code.  Instead, this PR compiles the variable expression and filtering into a `Liquid::C::Expression` object that is stored in the `Liquid::Variable` object's `@name` instance variable, which will be evaluated on render.

## Benchmark

The liquid benchmark only uses the assign tag `{% assign article = pages.frontpage %}` and doesn't use the echo tag, so the benchmark is mostly for unaffected code.  However, I wrote a micro-benchmark that shows the performance improvement

```ruby
# frozen_string_literal: true

require 'bundler/setup'
require 'benchmark/ips'
require 'liquid/c'

PARSE_CONTEXT = Liquid::ParseContext.new
CONTEXT = Liquid::Context.new('x' => 1, 'y' => 2)

def parse
  Liquid::Variable.new("x | plus: y", PARSE_CONTEXT)
end

Benchmark.ips do |x|
  x.report("parse") { parse }
  variable = parse
  x.report("render") { variable.render(CONTEXT) }
  x.report("parse & render") { parse.render(CONTEXT) }
end
```

result on master

```
               parse     88.381k (± 3.2%) i/s -    445.068k in   5.041305s
              render    510.144k (± 2.3%) i/s -      2.577M in   5.053979s
      parse & render     67.412k (± 4.0%) i/s -    342.414k in   5.088448s
```

result on this branch

```
               parse    631.565k (± 3.0%) i/s -      3.160M in   5.009016s
              render    961.840k (± 4.0%) i/s -      4.858M in   5.060674s
      parse & render    355.364k (± 3.3%) i/s -      1.790M in   5.041629s
```