### PR TITLE
Fix flaky test

### DIFF
--- a/test/unit/context_test.rb
+++ b/test/unit/context_test.rb
@@ -37,15 +37,16 @@ class ContextTest < Minitest::Test
 
     begin
       call_trace = TracePoint.trace(:call) do |t|
-        unless t.self == TracePoint || t.self.is_a?(TracePoint)
-          called_ruby_method_count += 1
-        end
+        next if t.self == TracePoint || t.self.is_a?(TracePoint)
+
+        called_ruby_method_count += 1
       end
 
       c_call_trace = TracePoint.trace(:c_call) do |t|
-        unless t.self == TracePoint || t.self.is_a?(TracePoint)
-          called_c_method_count += 1
-        end
+        next if t.self == TracePoint || t.self.is_a?(TracePoint)
+        next unless t.defined_class.name&.start_with?('Liquid')
+
+        called_c_method_count += 1
       end
 
       context.evaluate(lookup)


### PR DESCRIPTION
The `test_evaluating_a_variable_entirely_within_c` test is flaky. If we do the following:

```diff
diff --git a/test/unit/context_test.rb b/test/unit/context_test.rb
index 64b1852..eb5cd93 100644
--- a/test/unit/context_test.rb
+++ b/test/unit/context_test.rb
@@ -44,6 +44,7 @@ class ContextTest < Minitest::Test

       c_call_trace = TracePoint.trace(:c_call) do |t|
         unless t.self == TracePoint || t.self.is_a?(TracePoint)
+          puts "#{t.defined_class} #{t.method_id}"
           called_c_method_count += 1
         end
       end
```

We can see output such as:

```
 current
Thread abort_on_exception=
Thread::Queue pop
 current
Thread abort_on_exception=
Thread::Queue pop
Liquid::Context c_evaluate
```

And the failure is:

```
  1) Failure:
ContextTest#test_evaluating_a_variable_entirely_within_c [/Users/peter/src/github.com/Shopify/liquid-c/test/unit/context_test.rb:64]:
Expected: 1
  Actual: 7
```

I was able to reproduce this on Ruby 2.5.8 using seed 7822 (the repro is flaky and requires multiple tries).

As you can see, there are various other methods called that are also C functions.

The solution is to ignore all C function calls unless the class it is called on starts with `Liquid`.
