### PR TITLE
Ignore calls in other threads when counting ruby calls for a test

### DIFF
--- a/test/unit/context_test.rb
+++ b/test/unit/context_test.rb
@@ -35,15 +35,16 @@ class ContextTest < Minitest::Test
     called_ruby_method_count = 0
     called_c_method_count = 0
 
+    test_thread = Thread.current
     begin
       call_trace = TracePoint.trace(:call) do |t|
-        unless t.self == TracePoint || t.self.is_a?(TracePoint)
+        unless t.self == TracePoint || t.self.is_a?(TracePoint) || Thread.current != test_thread
           called_ruby_method_count += 1
         end
       end
 
       c_call_trace = TracePoint.trace(:c_call) do |t|
-        unless t.self == TracePoint || t.self.is_a?(TracePoint)
+        unless t.self == TracePoint || t.self.is_a?(TracePoint) || Thread.current != test_thread
           called_c_method_count += 1
         end
       end


### PR DESCRIPTION
Closes #113

## Problem

As stated in #113 we have flaky test failures in a test that is counting ruby calls using a tracepoint.

I had trouble reproducing the test failure locally, so I commented out the test using TracePoint and started a tracepoint in test_helper.rb, which was able to capture calls on the Thread module we were seeing.  After a bit of debugging, I found the source of the problem, that can be demonstrated using this in test/test_helper.rb

```ruby
main_thread = Thread.current

c_call_trace = TracePoint.trace(:c_call) do |t|
  if t.defined_class == Thread
    thread_name = Thread.current == main_thread ? "main" : "other"
    raise "unexpected call to #{t.defined_class}##{t.method_id} on #{thread_name} thread"
  end
end
```

which outputs

```
Traceback (most recent call last):
	8: from /Users/dylants/.gem/ruby/2.5.8/gems/minitest-5.14.2/lib/minitest.rb:68:in `block in autorun'
	7: from /Users/dylants/.gem/ruby/2.5.8/gems/minitest-5.14.2/lib/minitest.rb:138:in `run'
	6: from /Users/dylants/.gem/ruby/2.5.8/gems/minitest-5.14.2/lib/minitest/parallel.rb:27:in `start'
	5: from /Users/dylants/.gem/ruby/2.5.8/gems/minitest-5.14.2/lib/minitest/parallel.rb:27:in `map'
	4: from /Users/dylants/.gem/ruby/2.5.8/gems/minitest-5.14.2/lib/minitest/parallel.rb:27:in `each'
	3: from /Users/dylants/.gem/ruby/2.5.8/gems/minitest-5.14.2/lib/minitest/parallel.rb:27:in `times'
	2: from /Users/dylants/.gem/ruby/2.5.8/gems/minitest-5.14.2/lib/minitest/parallel.rb:28:in `block in start'
	1: from /Users/dylants/.gem/ruby/2.5.8/gems/minitest-5.14.2/lib/minitest/parallel.rb:28:in `new'
/Users/dylants/src/liquid-c/test/test_helper.rb:10:in `block in <top (required)>': unexpected call to Thread#initialize on main thread (RuntimeError)
```

So these calls are coming from this line in minitest: https://github.com/seattlerb/minitest/blob/v5.14.2/lib/minitest/parallel.rb#L29

## Solution

Filter calls to another thread in the test that was asserting on the number of ruby calls made.