### PR TITLE
Re-raise exceptions in VM that aren't from in VM variable rendering

### DIFF
--- a/test/unit/block_test.rb
+++ b/test/unit/block_test.rb
@@ -65,4 +65,21 @@ class BlockTest < MiniTest::Test
       0x0013: leave
     ASM
   end
+
+  def test_exception_renderer_exception
+    original_error = Liquid::Error.new("original")
+    handler_error = RuntimeError.new("exception handler error")
+    context = Liquid::Context.new('raise_error' => ->(_ctx) { raise(original_error) })
+    context.exception_renderer = lambda do |exc|
+      if exc == original_error
+        raise(handler_error)
+      end
+      exc
+    end
+    template = Liquid::Template.parse("{% assign x = raise_error %}")
+    exc = assert_raises(RuntimeError) do
+      template.render(context)
+    end
+    assert_equal(handler_error, exc)
+  end
 end


### PR DESCRIPTION
Fix #109

`vm_render_rescue` should never return true if `ip` is `NULL`.  This indicates that we aren't in an exception handling for VM code, so should re-raise the exception.

To do:
- [x] Write regression test