### PR TITLE
Use secure source for GitHub in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 source 'https://rubygems.org'
+git_source(:github) do |repo_name|
+  "https://github.com/#{repo_name}.git"
+end
 
 gemspec
 


### PR DESCRIPTION
When doing `bundle install` I get the following output:

```
The git source `git://github.com/Shopify/liquid.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.
```

This PR switches GitHub source in Gemfile to use HTTPS.