### PR TITLE
Rename disable_liquid_c_nodes method to liquid_c_nodes_disabled?

### DIFF
--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -8,7 +8,7 @@ require 'liquid/c'
 
 if ENV['LIQUID_C_DISABLE_VM']
   puts "-- Liquid-C VM Disabled"
-  Liquid::ParseContext.disable_liquid_c_nodes = true
+  Liquid::ParseContext.liquid_c_nodes_disabled = true
 end
 
 test_files = FileList[File.join(liquid_test_dir, 'integration/**/*_test.rb')]

--- a/test/unit/tokenizer_test.rb
+++ b/test/unit/tokenizer_test.rb
@@ -86,11 +86,11 @@ class TokenizerTest < Minitest::Test
 
     # Document.parse patch parse context update
     parse_context = Liquid::ParseContext.new
-    refute(parse_context.send(:disable_liquid_c_nodes))
+    refute(parse_context.liquid_c_nodes_disabled?)
     Liquid::Document.parse(liquid_c_tokenizer, parse_context)
-    refute(parse_context.send(:disable_liquid_c_nodes))
+    refute(parse_context.liquid_c_nodes_disabled?)
     Liquid::Document.parse(fallback_tokenizer, parse_context)
-    assert_equal(true, parse_context.send(:disable_liquid_c_nodes))
+    assert_equal(true, parse_context.liquid_c_nodes_disabled?)
   end
 
   private


### PR DESCRIPTION
Since the former is a verb, which makes the call site look like it is disabling the liquid VM, rather than accessing an attribute.