### PR TITLE
Fix invalid float with no leading integer

### DIFF
--- a/ext/liquid_c/lexer.c
+++ b/ext/liquid_c/lexer.c
@@ -109,7 +109,7 @@ const char *lex_one(const char *start, const char *end, lexer_token_t *token)
         }
     }
 
-    if (ISDIGIT(c) || c == '-') {
+    if (ISDIGIT(c) || (c == '-' && str + 1 < end && ISDIGIT(str[1]))) {
         int has_dot = 0;
         cur = str;
         while (++cur < end) {


### PR DESCRIPTION
When fuzzing with AFL there was an inconsistency in parsing floats. Liquid does not allow floats without a leading integer part, but liquid-c will allow a negative float without a leading integer part (e.g. liquid-c will parse `-.1` as `-0.1`). I've added tests for this in liquid.
