### PR TITLE
Fix negative string length

### DIFF
--- a/ext/liquid_c/tokenizer.c
+++ b/ext/liquid_c/tokenizer.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include "liquid.h"
 #include "tokenizer.h"
 #include "stringutil.h"
@@ -189,8 +190,12 @@ found:
 
     if (token->type == TOKEN_VARIABLE || token->type == TOKEN_TAG) {
         token->str_trimmed += 2 + token->lstrip;
-        token->len_trimmed -= 2 + token->lstrip + 2 + token->rstrip;
+        token->len_trimmed -= 2 + token->lstrip + 2;
+        if (token->rstrip && token->len_trimmed)
+            token->len_trimmed--;
     }
+
+    assert(token->len_trimmed >= 0);
 
     tokenizer->cursor += token->len_full;
 

--- a/test/unit/tokenizer_test.rb
+++ b/test/unit/tokenizer_test.rb
@@ -43,6 +43,11 @@ class TokenizerTest < Minitest::Test
     assert_equal(["", "funk", "", "so | brother"], tokenize(source, for_liquid_tag: true, trimmed: true))
   end
 
+  def test_invalid_tags
+    assert_equal([""], tokenize("{%-%}", trimmed: true))
+    assert_equal([""], tokenize("{{-}}", trimmed: true))
+  end
+
   def test_utf8_encoded_source
     source = 'auswählen'
     assert_equal(Encoding::UTF_8, source.encoding)


### PR DESCRIPTION
AFL caught a case that causes liquid-c to attempt to create a Ruby string with negative length.

When you try to parse liquid `{%-%}`, you get a

```
ArgumentError: negative string size (or size too big)
```

This is because the tokenizer treats `{%-%}` as if it has content inside of it, which it does not.