### PR TITLE
Allow space in between dot in attributes

### DIFF
--- a/ext/liquid_c/lexer.c
+++ b/ext/liquid_c/lexer.c
@@ -59,8 +59,6 @@ inline static const char *scan_past(const char *cur, const char *end, char targe
     const char *tok_end = str + (n); \
     token->type = (t); \
     token->val = str; \
-    if (str != start) token->flags |= TOKEN_SPACE_PREFIX; \
-    if (tok_end < end && ISSPACE(*tok_end)) token->flags |= TOKEN_SPACE_SUFFIX; \
     return (token->val_end = tok_end); \
 }
 

--- a/ext/liquid_c/lexer.h
+++ b/ext/liquid_c/lexer.h
@@ -24,9 +24,6 @@ enum lexer_token_type {
     TOKEN_END = 256
 };
 
-#define TOKEN_SPACE_PREFIX 0x1
-#define TOKEN_SPACE_SUFFIX 0x2
-#define TOKEN_SPACE_AFFIX (TOKEN_SPACE_PREFIX | TOKEN_SPACE_SUFFIX)
 #define TOKEN_FLOAT_NUMBER 0x4
 
 typedef struct lexer_token {

--- a/ext/liquid_c/parser.c
+++ b/ext/liquid_c/parser.c
@@ -128,11 +128,8 @@ static void parse_and_compile_variable_lookup(parser_t *p, vm_assembler_t *code)
             parser_must_consume(p, TOKEN_CLOSE_SQUARE);
             vm_assembler_add_lookup_key(code);
         } else if (p->cur.type == TOKEN_DOT) {
-            int has_space_affix = parser_consume_any(p).flags & TOKEN_SPACE_AFFIX;
+            parser_consume_any(p);
             VALUE key = token_to_rstr_leveraging_existing_symbol(parser_must_consume(p, TOKEN_IDENTIFIER));
-
-            if (has_space_affix)
-                rb_enc_raise(utf8_encoding, cLiquidSyntaxError, "Unexpected dot");
 
             if (rstring_eq(key, "size") || rstring_eq(key, "first") || rstring_eq(key, "last"))
                 vm_assembler_add_lookup_command(code, key);

--- a/test/unit/variable_test.rb
+++ b/test/unit/variable_test.rb
@@ -20,10 +20,6 @@ class VariableTest < Minitest::Test
     assert_raises(Liquid::SyntaxError) { variable_strict_parse('123.foo') }
     assert_raises(Liquid::SyntaxError) { variable_strict_parse(' | nothing') }
 
-    ['a .b', 'a. b', 'a . b'].each do |var|
-      assert_raises(Liquid::SyntaxError) { variable_strict_parse(var) }
-    end
-
     ['a -b', 'a- b', 'a - b'].each do |var|
       assert_raises(Liquid::SyntaxError) { variable_strict_parse(var) }
     end


### PR DESCRIPTION
Liquid allows any number of spaces between the dot when referring to an attribute but liquid-c raises a syntax error. I've included a test in liquid.
