### PR TITLE
Remove error on compiler warnings by default, except on CI

### DIFF
--- a/.github/workflows/liquid.yml
+++ b/.github/workflows/liquid.yml
@@ -23,4 +23,6 @@ jobs:
       - run: bundle install --jobs=3 --retry=3 --path=vendor/bundle
       - run: bundle exec rake
         continue-on-error: ${{ matrix.entry.allowed-failure }}
+        env:
+          LIQUID_C_PEDANTIC: 'true'
       - run: bundle exec rubocop

--- a/ext/liquid_c/extconf.rb
+++ b/ext/liquid_c/extconf.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 require 'mkmf'
 $CFLAGS << ' -std=c99 -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers'
-if RbConfig::CONFIG['host_os'] !~ /linux/ || Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7")
+# In Ruby 2.6 and earlier, the Ruby headers did not have struct timespec defined
+valid_headers = RbConfig::CONFIG['host_os'] !~ /linux/ || Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7")
+pedantic = !ENV['LIQUID_C_PEDANTIC'].to_s.empty?
+if pedantic && valid_headers
   $CFLAGS << ' -Werror'
 end
 compiler = RbConfig::MAKEFILE_CONFIG['CC']


### PR DESCRIPTION
## Problem

@tobi encountered a compiler warning that was treated as an error due when trying to compile liquid-c on linux with gcc 9.3.

This wasn't an error that was caught by CI and I wasn't able to reproduce this and I don't think we should have confidence that we can catch all compiler warnings before another developer experiences them.

## Solution

Only treat warnings as errors by default on CI.  We can set the `LIQUID_C_PENDANTIC` environment variable to opt-in to this locally.