### PR TITLE
Rename per-file extension init methods to distinguish from object init

### DIFF
--- a/ext/liquid_c/block.c
+++ b/ext/liquid_c/block.c
@@ -531,7 +531,7 @@ static VALUE block_body_add_filter(VALUE self, VALUE filter_name, VALUE num_args
 }
 
 
-void init_liquid_block()
+void liquid_define_block_body()
 {
     intern_raise_missing_variable_terminator = rb_intern("raise_missing_variable_terminator");
     intern_raise_missing_tag_terminator = rb_intern("raise_missing_tag_terminator");

--- a/ext/liquid_c/block.h
+++ b/ext/liquid_c/block.h
@@ -24,7 +24,7 @@ typedef struct block_body {
     } as;
 } block_body_t;
 
-void init_liquid_block();
+void liquid_define_block_body();
 
 static inline uint8_t *block_body_instructions_ptr(block_body_header_t *body)
 {

--- a/ext/liquid_c/context.c
+++ b/ext/liquid_c/context.c
@@ -194,7 +194,7 @@ VALUE context_filtering_p(VALUE self)
     return liquid_vm_filtering(self) ? Qtrue : Qfalse;
 }
 
-void init_liquid_context()
+void liquid_define_context()
 {
     id_has_key = rb_intern("key?");
     id_aset = rb_intern("[]=");

--- a/ext/liquid_c/context.h
+++ b/ext/liquid_c/context.h
@@ -18,7 +18,7 @@ typedef struct context {
     bool strict_filters;
 } context_t;
 
-void init_liquid_context();
+void liquid_define_context();
 void context_internal_init(VALUE context_obj, context_t *context);
 void context_mark(context_t *context);
 VALUE context_find_variable(context_t *context, VALUE key, VALUE raise_on_not_found);

--- a/ext/liquid_c/document_body.c
+++ b/ext/liquid_c/document_body.c
@@ -78,7 +78,7 @@ void document_body_write_block_body(VALUE self, bool blank, uint32_t render_scor
     rb_ary_cat(body->constants, (VALUE *)code->constants.data, constants_len);
 }
 
-void init_liquid_document_body()
+void liquid_define_document_body()
 {
     cLiquidCDocumentBody = rb_define_class_under(mLiquidC, "DocumentBody", rb_cObject);
     rb_global_variable(&cLiquidCDocumentBody);

--- a/ext/liquid_c/document_body.h
+++ b/ext/liquid_c/document_body.h
@@ -28,7 +28,7 @@ typedef struct document_body_entry {
     size_t buffer_offset;
 } document_body_entry_t;
 
-void init_liquid_document_body();
+void liquid_define_document_body();
 VALUE document_body_new_instance();
 void document_body_write_block_body(VALUE self, bool blank, uint32_t render_score, vm_assembler_t *code, document_body_entry_t *entry);
 

--- a/ext/liquid_c/expression.c
+++ b/ext/liquid_c/expression.c
@@ -97,7 +97,7 @@ static VALUE expression_disassemble(VALUE self)
                                     (const VALUE *)expression->code.constants.data);
 }
 
-void init_liquid_expression()
+void liquid_define_expression()
 {
     cLiquidCExpression = rb_define_class_under(mLiquidC, "Expression", rb_cObject);
     rb_undef_alloc_func(cLiquidCExpression);

--- a/ext/liquid_c/expression.h
+++ b/ext/liquid_c/expression.h
@@ -11,7 +11,7 @@ typedef struct expression {
     vm_assembler_t code;
 } expression_t;
 
-void init_liquid_expression();
+void liquid_define_expression();
 
 VALUE expression_new(VALUE klass, expression_t **expression_ptr);
 VALUE expression_evaluate(VALUE self, VALUE context);

--- a/ext/liquid_c/liquid.c
+++ b/ext/liquid_c/liquid.c
@@ -76,19 +76,19 @@ void Init_liquid_c(void)
     cLiquidRangeLookup = rb_const_get(mLiquid, rb_intern("RangeLookup"));
     rb_global_variable(&cLiquidRangeLookup);
 
-    init_liquid_tokenizer();
-    init_liquid_parser();
-    init_liquid_raw();
-    init_liquid_resource_limits();
-    init_liquid_expression();
-    init_liquid_variable();
-    init_liquid_document_body();
-    init_liquid_block();
-    init_liquid_context();
-    init_liquid_parse_context();
-    init_liquid_variable_lookup();
-    vm_assembler_pool_init();
-    init_liquid_vm();
-    init_liquid_usage();
+    liquid_define_tokenizer();
+    liquid_define_parser();
+    liquid_define_raw();
+    liquid_define_resource_limits();
+    liquid_define_expression();
+    liquid_define_variable();
+    liquid_define_document_body();
+    liquid_define_block_body();
+    liquid_define_context();
+    liquid_define_parse_context();
+    liquid_define_variable_lookup();
+    liquid_define_vm_assembler_pool();
+    liquid_define_vm();
+    liquid_define_usage();
 }
 

--- a/ext/liquid_c/parse_context.c
+++ b/ext/liquid_c/parse_context.c
@@ -62,7 +62,7 @@ void parse_context_remove_vm_assembler_pool(VALUE self)
 }
 
 
-void init_liquid_parse_context()
+void liquid_define_parse_context()
 {
     id_document_body = rb_intern("document_body");
     id_vm_assembler_pool = rb_intern("vm_assembler_pool");

--- a/ext/liquid_c/parse_context.h
+++ b/ext/liquid_c/parse_context.h
@@ -5,7 +5,7 @@
 #include <stdbool.h>
 #include "vm_assembler_pool.h"
 
-void init_liquid_parse_context();
+void liquid_define_parse_context();
 bool parse_context_document_body_initialized_p(VALUE self);
 void parse_context_init_document_body(VALUE self);
 VALUE parse_context_get_document_body(VALUE self);

--- a/ext/liquid_c/parser.c
+++ b/ext/liquid_c/parser.c
@@ -265,7 +265,7 @@ void parse_and_compile_expression(parser_t *p, vm_assembler_t *code)
     }
 }
 
-void init_liquid_parser(void)
+void liquid_define_parser(void)
 {
     id_to_i = rb_intern("to_i");
     idEvaluate = rb_intern("evaluate");

--- a/ext/liquid_c/parser.h
+++ b/ext/liquid_c/parser.h
@@ -18,7 +18,7 @@ lexer_token_t parser_consume_any(parser_t *parser);
 void parse_and_compile_expression(parser_t *p, vm_assembler_t *code);
 VALUE try_parse_constant_expression(parser_t *p);
 
-void init_liquid_parser(void);
+void liquid_define_parser(void);
 
 #endif
 

--- a/ext/liquid_c/raw.c
+++ b/ext/liquid_c/raw.c
@@ -92,7 +92,7 @@ static VALUE raw_parse_method(VALUE self, VALUE tokens)
     return Qnil;
 }
 
-void init_liquid_raw()
+void liquid_define_raw()
 {
     id_block_name = rb_intern("block_name");
     id_raise_tag_never_closed = rb_intern("raise_tag_never_closed");

--- a/ext/liquid_c/raw.h
+++ b/ext/liquid_c/raw.h
@@ -1,6 +1,6 @@
 #ifndef LIQUID_RAW_H
 #define LIQUID_RAW_H
 
-void init_liquid_raw();
+void liquid_define_raw();
 
 #endif

--- a/ext/liquid_c/resource_limits.c
+++ b/ext/liquid_c/resource_limits.c
@@ -254,7 +254,7 @@ static VALUE resource_limits_reset_method(VALUE self)
     return Qnil;
 }
 
-void init_liquid_resource_limits()
+void liquid_define_resource_limits()
 {
     cLiquidResourceLimits = rb_define_class_under(mLiquidC, "ResourceLimits", rb_cObject);
     rb_global_variable(&cLiquidResourceLimits);

--- a/ext/liquid_c/resource_limits.h
+++ b/ext/liquid_c/resource_limits.h
@@ -15,7 +15,7 @@ extern VALUE cLiquidResourceLimits;
 extern const rb_data_type_t resource_limits_data_type;
 #define ResourceLimits_Get_Struct(obj, sval) TypedData_Get_Struct(obj, resource_limits_t, &resource_limits_data_type, sval)
 
-void init_liquid_resource_limits();
+void liquid_define_resource_limits();
 void resource_limits_raise_limits_reached(resource_limits_t *resource_limit);
 void resource_limits_increment_render_score(resource_limits_t *resource_limits, long amount);
 void resource_limits_increment_write_score(resource_limits_t *resource_limits, VALUE output);

--- a/ext/liquid_c/tokenizer.c
+++ b/ext/liquid_c/tokenizer.c
@@ -278,7 +278,7 @@ static VALUE tokenizer_bug_compatible_whitespace_trimming(VALUE self) {
     return Qnil;
 }
 
-void init_liquid_tokenizer()
+void liquid_define_tokenizer()
 {
     cLiquidTokenizer = rb_define_class_under(mLiquidC, "Tokenizer", rb_cObject);
     rb_global_variable(&cLiquidTokenizer);

--- a/ext/liquid_c/tokenizer.h
+++ b/ext/liquid_c/tokenizer.h
@@ -35,7 +35,7 @@ extern VALUE cLiquidTokenizer;
 extern const rb_data_type_t tokenizer_data_type;
 #define Tokenizer_Get_Struct(obj, sval) TypedData_Get_Struct(obj, tokenizer_t, &tokenizer_data_type, sval)
 
-void init_liquid_tokenizer();
+void liquid_define_tokenizer();
 void tokenizer_next(tokenizer_t *tokenizer, token_t *token);
 
 void tokenizer_setup_for_liquid_tag(tokenizer_t *tokenizer, const char *cursor, const char *cursor_end, int line_number);

--- a/ext/liquid_c/usage.c
+++ b/ext/liquid_c/usage.c
@@ -9,7 +9,7 @@ void usage_increment(const char *name)
     rb_funcall(cLiquidUsage, id_increment, 1, name_str);
 }
 
-void init_liquid_usage()
+void liquid_define_usage()
 {
     cLiquidUsage = rb_const_get(mLiquid, rb_intern("Usage"));
     rb_global_variable(&cLiquidUsage);

--- a/ext/liquid_c/usage.h
+++ b/ext/liquid_c/usage.h
@@ -3,7 +3,7 @@
 
 #include "liquid.h"
 
-void init_liquid_usage();
+void liquid_define_usage();
 void usage_increment(const char *name);
 
 #endif

--- a/ext/liquid_c/variable.c
+++ b/ext/liquid_c/variable.c
@@ -195,7 +195,7 @@ static VALUE variable_expression_evaluate(VALUE self, VALUE context)
     return rb_rescue(try_variable_expression_evaluate, (VALUE)&args, rescue_variable_expression_evaluate, (VALUE)&args);
 }
 
-void init_liquid_variable(void)
+void liquid_define_variable(void)
 {
     id_rescue_strict_parse_syntax_error = rb_intern("rescue_strict_parse_syntax_error");
 

--- a/ext/liquid_c/variable.h
+++ b/ext/liquid_c/variable.h
@@ -14,7 +14,7 @@ typedef struct variable_parse_args {
     VALUE parse_context;
 } variable_parse_args_t;
 
-void init_liquid_variable(void);
+void liquid_define_variable(void);
 void internal_variable_compile(variable_parse_args_t *parse_args, unsigned int line_number);
 void internal_variable_compile_evaluate(variable_parse_args_t *parse_args);
 

--- a/ext/liquid_c/variable_lookup.c
+++ b/ext/liquid_c/variable_lookup.c
@@ -27,7 +27,7 @@ VALUE variable_lookup_key(VALUE context, VALUE object, VALUE key, bool is_comman
     return Qnil;
 }
 
-void init_liquid_variable_lookup()
+void liquid_define_variable_lookup()
 {
     id_has_key = rb_intern("key?");
     id_aref = rb_intern("[]");

--- a/ext/liquid_c/variable_lookup.h
+++ b/ext/liquid_c/variable_lookup.h
@@ -1,7 +1,7 @@
 #if !defined(LIQUID_VARIABLE_LOOKUP_H)
 #define LIQUID_VARIABLE_LOOKUP_H
 
-void init_liquid_variable_lookup();
+void liquid_define_variable_lookup();
 VALUE variable_lookup_key(VALUE context, VALUE object, VALUE key, bool is_command);
 
 #endif

--- a/ext/liquid_c/vm.c
+++ b/ext/liquid_c/vm.c
@@ -545,7 +545,7 @@ void liquid_vm_render(block_body_header_t *body, const VALUE *const_ptr, VALUE c
 }
 
 
-void init_liquid_vm()
+void liquid_define_vm()
 {
     id_render_node = rb_intern("render_node");
     id_vm = rb_intern("vm");

--- a/ext/liquid_c/vm.h
+++ b/ext/liquid_c/vm.h
@@ -12,7 +12,7 @@ typedef struct vm {
     context_t context;
 } vm_t;
 
-void init_liquid_vm();
+void liquid_define_vm();
 vm_t *vm_from_context(VALUE context);
 void liquid_vm_render(block_body_header_t *block, const VALUE *const_ptr, VALUE context, VALUE output);
 void liquid_vm_next_instruction(const uint8_t **ip_ptr, const size_t **const_ptr_ptr);

--- a/ext/liquid_c/vm_assembler.h
+++ b/ext/liquid_c/vm_assembler.h
@@ -41,7 +41,6 @@ typedef struct vm_assembler {
     bool parsing; // prevent executing when incomplete or extending when complete
 } vm_assembler_t;
 
-void init_liquid_vm_assembler();
 void vm_assembler_init(vm_assembler_t *code);
 void vm_assembler_reset(vm_assembler_t *code);
 void vm_assembler_free(vm_assembler_t *code);

--- a/ext/liquid_c/vm_assembler_pool.c
+++ b/ext/liquid_c/vm_assembler_pool.c
@@ -87,7 +87,7 @@ void vm_assembler_pool_recycle_assembler(vm_assembler_pool_t *pool, vm_assembler
     pool->freelist = element;
 }
 
-void vm_assembler_pool_init()
+void liquid_define_vm_assembler_pool()
 {
     cLiquidCVMAssemblerPool = rb_define_class_under(mLiquidC, "VMAssemblerPool", rb_cObject);
     rb_global_variable(&cLiquidCVMAssemblerPool);

--- a/ext/liquid_c/vm_assembler_pool.h
+++ b/ext/liquid_c/vm_assembler_pool.h
@@ -17,7 +17,7 @@ typedef struct vm_assembler_pool {
 extern const rb_data_type_t vm_assembler_pool_data_type;
 #define VMAssemblerPool_Get_Struct(obj, sval) TypedData_Get_Struct(obj, vm_assembler_pool_t, &vm_assembler_pool_data_type, sval)
 
-void vm_assembler_pool_init();
+void liquid_define_vm_assembler_pool();
 void vm_assembler_pool_gc_mark(vm_assembler_pool_t *pool);
 VALUE vm_assembler_pool_new();
 vm_assembler_t *vm_assembler_pool_alloc_assembler(vm_assembler_pool_t *pool);


### PR DESCRIPTION
## Problem

We have two sets of initialization functions.  We have object initialization functions and functions to MRI extension initialization functions.  These used to be subtle distinguished by one using an init_liquid_ prefix and one using an _init suffix, however, `vm_assembler_pool_init` was introduced which doesn't even follow this convention.

## Solution

The per-file MRI extension initialization functions are mostly defining classes, modules, methods, etc.  So use a `define_` prefix for these after the `liquid_` namespace prefix (meant to avoid naming conflicts).