### PR TITLE
Use `-fvisibility=hidden` in CFLAGS to only export Init_liquid_c

### DIFF
--- a/ext/liquid_c/extconf.rb
+++ b/ext/liquid_c/extconf.rb
@@ -1,17 +1,15 @@
 # frozen_string_literal: true
 require 'mkmf'
 $CFLAGS << ' -std=c99 -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers'
+append_cflags('-fvisibility=hidden')
 # In Ruby 2.6 and earlier, the Ruby headers did not have struct timespec defined
 valid_headers = RbConfig::CONFIG['host_os'] !~ /linux/ || Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7")
 pedantic = !ENV['LIQUID_C_PEDANTIC'].to_s.empty?
 if pedantic && valid_headers
   $CFLAGS << ' -Werror'
 end
-compiler = RbConfig::MAKEFILE_CONFIG['CC']
 if ENV['DEBUG'] == 'true'
-  if /gcc|g\+\+/.match?(compiler)
-    $CFLAGS << ' -fbounds-check'
-  end
+  append_cflags('-fbounds-check')
   CONFIG['optflags'] = ' -O0'
 else
   $CFLAGS << ' -DNDEBUG'

--- a/ext/liquid_c/liquid.c
+++ b/ext/liquid_c/liquid.c
@@ -34,7 +34,7 @@ __attribute__((noreturn)) void raise_non_utf8_encoding_error(VALUE string, const
     rb_raise(rb_eEncCompatError, "non-UTF8 encoded %s (%"PRIsVALUE") not supported", value_name, rb_obj_encoding(string));
 }
 
-void Init_liquid_c(void)
+RUBY_FUNC_EXPORTED void Init_liquid_c(void)
 {
     id_evaluate = rb_intern("evaluate");
     id_to_liquid = rb_intern("to_liquid");


### PR DESCRIPTION
## Problem

We are exporting a lot more shared library symbols than necessary, since it is including any function that isn't declared `static` in the externally accessible symbol table.  However, the only symbol that ruby needs to load the library is Init_liquid_c.  The other symbols needlessly increase the chance of a conflict with another shared library used in the ruby process, especially since this library doesn't consistently use a prefix (e.g. `liquid_`) to namespace all these symbols.

## Solution

Avoid exporting symbols by default using the `-fvisibility=hidden` compiler flag then use `RUBY_FUNC_EXPORTED` to export `Init_liquid_c`, which is the only symbol ruby needs defined.  I used mkmf's `append_cflags` to make the CFLAGS addition conditional on it being supported (e.g. for gcc and clang).