### PR TITLE
Add OP_BUILTIN_FILTER that avoids the need for a constant for these filters

### DIFF
--- a/ext/liquid_c/extconf.rb
+++ b/ext/liquid_c/extconf.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require 'mkmf'
-$CFLAGS << ' -std=c99 -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers'
+$CFLAGS << ' -std=c11 -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers'
 append_cflags('-fvisibility=hidden')
 # In Ruby 2.6 and earlier, the Ruby headers did not have struct timespec defined
 valid_headers = RbConfig::CONFIG['host_os'] !~ /linux/ || Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7")

--- a/ext/liquid_c/liquid.c
+++ b/ext/liquid_c/liquid.c
@@ -88,6 +88,7 @@ RUBY_FUNC_EXPORTED void Init_liquid_c(void)
     liquid_define_parse_context();
     liquid_define_variable_lookup();
     liquid_define_vm_assembler_pool();
+    liquid_define_vm_assembler();
     liquid_define_vm();
     liquid_define_usage();
 }

--- a/ext/liquid_c/vm.c
+++ b/ext/liquid_c/vm.c
@@ -310,8 +310,15 @@ static VALUE vm_render_until_error(VALUE uncast_args)
                 break;
             }
             case OP_FILTER:
+            case OP_BUILTIN_FILTER:
             {
-                VALUE filter_name = *const_ptr++;
+                VALUE filter_name;
+                if (ip[-1] == OP_FILTER) {
+                    filter_name = *const_ptr++;
+                } else {
+                    assert(ip[-1] == OP_BUILTIN_FILTER);
+                    filter_name = builtin_filters[*ip++].sym;
+                }
                 uint8_t num_args = *ip++; // includes input argument
                 VALUE *args_ptr = vm_stack_pop_n_use_in_place(vm, num_args);
                 VALUE result = vm_invoke_filter(vm, filter_name, num_args, args_ptr);
@@ -427,6 +434,7 @@ void liquid_vm_next_instruction(const uint8_t **ip_ptr, const VALUE **const_ptr_
             ip++;
             break;
 
+        case OP_BUILTIN_FILTER:
         case OP_PUSH_INT16:
             ip += 2;
             break;

--- a/test/unit/block_test.rb
+++ b/test/unit/block_test.rb
@@ -74,10 +74,10 @@ class BlockTest < MiniTest::Test
       0x000b: push_const("allow_false")
       0x000c: push_true
       0x000d: hash_new(1)
-      0x000f: filter(name: :default, num_args: 3)
-      0x0011: pop_write
-      0x0012: write_node(#{increment_node.inspect})
-      0x0013: leave
+      0x000f: builtin_filter(name: :default, num_args: 3)
+      0x0012: pop_write
+      0x0013: write_node(#{increment_node.inspect})
+      0x0014: leave
     ASM
   end
 


### PR DESCRIPTION
As part of https://github.com/Shopify/liquid-c/issues/84, we will want to reduce dependence on the moving constants pointer.  Instead, we can use a constant table and encode an index into instructions to use for looking up the constant.  However, we probably have to be mindful of performance overhead from multibyte constant lookups.

For builtin filters (defined in Liquid::StandardFilters), this PR avoids using any constant and instead uses a separate OP_BUILTIN_FILTER with a byte index operand that won't use any index in a future constant table.