### PR TITLE
Remove duplicated function

### DIFF
--- a/ext/liquid_c/vm.h
+++ b/ext/liquid_c/vm.h
@@ -22,9 +22,4 @@ VALUE liquid_vm_evaluate(VALUE context, vm_assembler_t *code);
 vm_t *vm_from_context(VALUE context);
 VALUE vm_translate_if_filter_argument_error(vm_t *vm, VALUE exception);
 
-static inline unsigned int decode_node_line_number(const uint8_t *node_line_number)
-{
-    return (node_line_number[0] << 16) | (node_line_number[1] << 8) | node_line_number[2];
-}
-
 #endif

--- a/ext/liquid_c/vm_assembler.c
+++ b/ext/liquid_c/vm_assembler.c
@@ -151,7 +151,7 @@ VALUE vm_assembler_disassemble(const uint8_t *start_ip, const uint8_t *end_ip, c
 
             case OP_RENDER_VARIABLE_RESCUE:
             {
-                unsigned int line_number = decode_node_line_number(ip + 1);
+                unsigned int line_number = bytes_to_uint24(ip + 1);
                 rb_str_catf(output, "render_variable_rescue(line_number: %u)\n", line_number);
                 break;
             }


### PR DESCRIPTION
I noticed that `OP_RENDER_VARIABLE_RESCUE` has its own `decode_node_line_number` function used to decode the 24-bit integer. This function is a duplicate of the [`bytes_to_uint24` function](https://github.com/Shopify/liquid-c/blob/93ba80c9606f9ddeae91807449c434aecd806c09/ext/liquid_c/intutil.h#L6).