### PR TITLE
Write raw tags directly to buffer

### DIFF
--- a/ext/liquid_c/block.c
+++ b/ext/liquid_c/block.c
@@ -248,7 +248,17 @@ static tag_markup_t internal_block_body_parse(block_body_t *body, parse_context_
                 if (body->as.intermediate.blank && !RTEST(rb_funcall(new_tag, intern_is_blank, 0)))
                     body->as.intermediate.blank = false;
 
-                vm_assembler_add_write_node(body->as.intermediate.code, new_tag);
+                if (tokenizer->raw_tag_body) {
+                    if (tokenizer->raw_tag_body_len) {
+                        vm_assembler_add_write_raw(body->as.intermediate.code, tokenizer->raw_tag_body,
+                                                tokenizer->raw_tag_body_len);
+                    }
+                    tokenizer->raw_tag_body = NULL;
+                    tokenizer->raw_tag_body_len = 0;
+                } else {
+                    vm_assembler_add_write_node(body->as.intermediate.code, new_tag);
+                }
+
                 render_score_increment += 1;
                 break;
             }

--- a/ext/liquid_c/raw.c
+++ b/ext/liquid_c/raw.c
@@ -82,6 +82,8 @@ static VALUE raw_parse_method(VALUE self, VALUE tokens)
             body_len += match.body_len;
             VALUE body_str = rb_enc_str_new(body, body_len, utf8_encoding);
             rb_ivar_set(self, id_ivar_body, body_str);
+            tokenizer->raw_tag_body = RSTRING_PTR(body_str);
+            tokenizer->raw_tag_body_len = (unsigned int)body_len;
             return Qnil;
         }
 

--- a/ext/liquid_c/tokenizer.c
+++ b/ext/liquid_c/tokenizer.c
@@ -38,6 +38,8 @@ static VALUE tokenizer_allocate(VALUE klass)
     obj = TypedData_Make_Struct(klass, tokenizer_t, &tokenizer_data_type, tokenizer);
     tokenizer->source = Qnil;
     tokenizer->bug_compatible_whitespace_trimming = false;
+    tokenizer->raw_tag_body = NULL;
+    tokenizer->raw_tag_body_len = 0;
     return obj;
 }
 

--- a/ext/liquid_c/tokenizer.h
+++ b/ext/liquid_c/tokenizer.h
@@ -29,6 +29,9 @@ typedef struct tokenizer {
 
     // Temporary to test rollout of the fix for this bug
     bool bug_compatible_whitespace_trimming;
+
+    char *raw_tag_body;
+    unsigned int raw_tag_body_len;
 } tokenizer_t;
 
 extern VALUE cLiquidTokenizer;


### PR DESCRIPTION
Write raw tags directly to the instructions buffer as an `OP_WRITE_RAW` instruction. This is an alternative to #134.

# Benchmarks

There is a small performance hit during parsing, but a slight performance improvement during rendering in the microbenchmark.

Master:

```
               parse    105.637k (± 6.9%) i/s -    535.392k in   5.092843s
              render    206.248k (± 8.5%) i/s -      1.036M in   5.058648s
      parse & render     57.954k (± 6.6%) i/s -    292.464k in   5.069258s
```

This branch:

```
               parse     97.280k (± 3.3%) i/s -    486.423k in   5.006012s
              render    225.835k (± 6.2%) i/s -      1.126M in   5.009018s
      parse & render     53.268k (± 8.9%) i/s -    268.041k in   5.077031s
```

Script:

```ruby
require "benchmark/ips"
require "liquid"
require "liquid/c"

source = <<~LIQUID
  {% raw %}
    {% test %}
    hello world
    {% endtest %}
  {% endraw %}
LIQUID

template = Liquid::Template.parse(source)

Benchmark.ips do |x|
  x.report("parse") do |times|
    times.times do
      Liquid::Template.parse(source)
    end
  end

  x.report("render") do |times|
    times.times do
      template.render!
    end
  end

  x.report("parse & render") do |times|
    times.times do
      Liquid::Template.parse(source).render!
    end
  end
end
```
