### PR TITLE
Make Liquid::C::Tokenizer#shift private so it is only used for testing

### DIFF
--- a/ext/liquid_c/tokenizer.c
+++ b/ext/liquid_c/tokenizer.c
@@ -287,12 +287,12 @@ void liquid_define_tokenizer()
 
     rb_define_alloc_func(cLiquidTokenizer, tokenizer_allocate);
     rb_define_method(cLiquidTokenizer, "initialize", tokenizer_initialize_method, 3);
-    rb_define_method(cLiquidTokenizer, "shift", tokenizer_shift_method, 0);
     rb_define_method(cLiquidTokenizer, "line_number", tokenizer_line_number_method, 0);
     rb_define_method(cLiquidTokenizer, "for_liquid_tag", tokenizer_for_liquid_tag_method, 0);
     rb_define_method(cLiquidTokenizer, "bug_compatible_whitespace_trimming!", tokenizer_bug_compatible_whitespace_trimming, 0);
 
     // For testing the internal token representation.
+    rb_define_private_method(cLiquidTokenizer, "shift", tokenizer_shift_method, 0);
     rb_define_private_method(cLiquidTokenizer, "shift_trimmed", tokenizer_shift_trimmed_method, 0);
 }
 

--- a/lib/liquid/c.rb
+++ b/lib/liquid/c.rb
@@ -41,20 +41,16 @@ module Liquid
   end
 end
 
-Liquid::Tokenizer.class_eval do
-  def self.new(source, line_numbers = false, line_number: nil, for_liquid_tag: false)
-    source = source.to_s
-    if Liquid::C.enabled && source.bytesize <= Liquid::C::Tokenizer::MAX_SOURCE_BYTE_SIZE
-      source = source.encode(Encoding::UTF_8)
-      Liquid::C::Tokenizer.new(source, line_number || (line_numbers ? 1 : 0), for_liquid_tag)
-    else
-      super
-    end
-  end
-end
-
 Liquid::Raw.class_eval do
   alias_method :ruby_parse, :parse
+
+  def parse(tokenizer)
+    if parse_context.liquid_c_nodes_disabled?
+      ruby_parse(tokenizer)
+    else
+      c_parse(tokenizer)
+    end
+  end
 end
 
 Liquid::ParseContext.class_eval do
@@ -73,6 +69,22 @@ Liquid::ParseContext.class_eval do
     end
   end
 
+  alias_method :ruby_new_tokenizer, :new_tokenizer
+
+  def new_tokenizer(source, start_line_number: nil, for_liquid_tag: false)
+    unless liquid_c_nodes_disabled?
+      source = source.to_s
+      if source.bytesize <= Liquid::C::Tokenizer::MAX_SOURCE_BYTE_SIZE
+        source = source.encode(Encoding::UTF_8)
+        return Liquid::C::Tokenizer.new(source, start_line_number || 0, for_liquid_tag)
+      else
+        @liquid_c_nodes_disabled = true
+      end
+    end
+
+    ruby_new_tokenizer(source, start_line_number: start_line_number, for_liquid_tag: for_liquid_tag)
+  end
+
   # @api private
   def liquid_c_nodes_disabled?
     # Liquid::Profiler exposes the internal parse tree that we don't want to build when
@@ -80,27 +92,19 @@ Liquid::ParseContext.class_eval do
     # Also, some templates are parsed before the profiler is running, on which case we
     # provide the `disable_liquid_c_nodes` option to enable the Ruby AST to be produced
     # so the profiler can use it on future runs.
-    @liquid_c_nodes_disabled ||= !Liquid::C.enabled || @template_options[:profile] ||
+    return @liquid_c_nodes_disabled if defined?(@liquid_c_nodes_disabled)
+    @liquid_c_nodes_disabled = !Liquid::C.enabled || @template_options[:profile] ||
       @template_options[:disable_liquid_c_nodes] || self.class.liquid_c_nodes_disabled
   end
-
-  # @api private
-  attr_writer :liquid_c_nodes_disabled
 end
 
 module Liquid
   module C
     module DocumentClassPatch
       def parse(tokenizer, parse_context)
-        if tokenizer.is_a?(Liquid::C::Tokenizer)
+        if tokenizer.is_a?(Liquid::C::Tokenizer) && parse_context[:bug_compatible_whitespace_trimming]
           # Temporary to test rollout of the fix for this bug
-          if parse_context[:bug_compatible_whitespace_trimming]
-            tokenizer.bug_compatible_whitespace_trimming!
-          end
-        else
-          # Liquid::Tokenizer.new may return a Liquid::Tokenizer if the source is too large
-          # to be supported, so indicate in the parse context that the liquid VM won't be used
-          parse_context.liquid_c_nodes_disabled = true
+          tokenizer.bug_compatible_whitespace_trimming!
         end
         super
       end
@@ -237,12 +241,10 @@ module Liquid
           Liquid::Context.send(:alias_method, :evaluate, :c_evaluate)
           Liquid::Context.send(:alias_method, :find_variable, :c_find_variable_kwarg)
           Liquid::Context.send(:alias_method, :strict_variables=, :c_strict_variables=)
-          Liquid::Raw.send(:alias_method, :parse, :c_parse)
         else
           Liquid::Context.send(:alias_method, :evaluate, :ruby_evaluate)
           Liquid::Context.send(:alias_method, :find_variable, :ruby_find_variable)
           Liquid::Context.send(:alias_method, :strict_variables=, :ruby_strict_variables=)
-          Liquid::Raw.send(:alias_method, :parse, :ruby_parse)
         end
       end
     end


### PR DESCRIPTION
Depends on https://github.com/Shopify/liquid/pull/1386

## Problem

The liquid template (de)serialization support that is being added by https://github.com/Shopify/liquid-c/pull/138 won't actually support `Liquid::C::Tokenizer#shift` being used during parsing.  The method would seem to work for the initial parsing, but then it would fail on deserialization where there is no longer a tokenizer.

## Solution

Leverage https://github.com/Shopify/liquid/pull/1386 to update the tokenizer monkey patch to instead be on Liquid::ParseContext.new_tokenizer so that we avoid using the Liquid::C::Tokenizer when the liquid-c VM is disabled.

Make Liquid::C::Tokenizer#shift private, like `shift_trimmed`, and only use it for testing.