### PR TITLE
Use GC.verify_compaction_references when available to validate C references

### DIFF
--- a/.github/workflows/liquid.yml
+++ b/.github/workflows/liquid.yml
@@ -6,8 +6,9 @@ jobs:
     strategy:
       matrix:
         entry:
-          - { ruby: 2.5, allowed-failure: false }
-          - { ruby: 2.7, allowed-failure: false }
+          - { ruby: '2.5', allowed-failure: false }
+          - { ruby: '2.7', allowed-failure: false }
+          - { ruby: '3.0', allowed-failure: false }
           - { ruby: ruby-head, allowed-failure: true }
     name: test (${{ matrix.entry.ruby }})
     steps:

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -16,12 +16,3 @@ test_files << File.join(liquid_test_dir, 'unit/tokenizer_unit_test.rb')
 test_files.each do |test_file|
   require test_file
 end
-
-module GCCompactSetup
-  def setup
-    GC.compact if GC.respond_to?(:compact)
-    super
-  end
-end
-
-Minitest::Test.prepend(GCCompactSetup)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,9 @@
 # frozen_string_literal: true
 require 'minitest/autorun'
 require 'liquid/c'
+
+if GC.respond_to?(:verify_compaction_references)
+  # This method was added in Ruby 3.0.0. Calling it this way asks the GC to
+  # move objects around, helping to find object movement bugs.
+  GC.verify_compaction_references(double_heap: true, toward: :empty)
+end


### PR DESCRIPTION
Improved over https://github.com/Shopify/liquid-c/pull/55

It's only available from 3.0 onwards, but since we run 3.0 on CI it should protect us from this kind of bugs in the future, much better than running a simple `GC.compact`.