### PR TITLE
Fix filter error translation for context evaluate of variable expression

### DIFF
--- a/ext/liquid_c/context.c
+++ b/ext/liquid_c/context.c
@@ -19,8 +19,14 @@ static VALUE context_evaluate(VALUE self, VALUE expression)
     switch (RB_BUILTIN_TYPE(expression)) {
         case T_DATA:
         {
-            if (RTYPEDDATA_P(expression) && RTYPEDDATA_TYPE(expression) == &expression_data_type)
-                return internal_expression_evaluate(DATA_PTR(expression), self);
+            if (RTYPEDDATA_P(expression) && RTYPEDDATA_TYPE(expression) == &expression_data_type) {
+                if (RBASIC_CLASS(expression) == cLiquidCExpression) {
+                    return internal_expression_evaluate(DATA_PTR(expression), self);
+                } else {
+                    assert(RBASIC_CLASS(expression) == cLiquidCVariableExpression);
+                    return internal_variable_expression_evaluate(DATA_PTR(expression), self);
+                }
+            }
             break; // e.g. BigDecimal
         }
         case T_OBJECT: // may be Liquid::VariableLookup or Liquid::RangeLookup

--- a/ext/liquid_c/expression.c
+++ b/ext/liquid_c/expression.c
@@ -75,8 +75,6 @@ static VALUE expression_strict_parse(VALUE klass, VALUE markup)
     return expr_obj;
 }
 
-#define Expression_Get_Struct(obj, sval) TypedData_Get_Struct(obj, expression_t, &expression_data_type, sval)
-
 VALUE expression_evaluate(VALUE self, VALUE context)
 {
     expression_t *expression;

--- a/ext/liquid_c/expression.h
+++ b/ext/liquid_c/expression.h
@@ -11,6 +11,9 @@ typedef struct expression {
     vm_assembler_t code;
 } expression_t;
 
+extern const rb_data_type_t expression_data_type;
+#define Expression_Get_Struct(obj, sval) TypedData_Get_Struct(obj, expression_t, &expression_data_type, sval)
+
 void init_liquid_expression();
 
 VALUE expression_new(VALUE klass, expression_t **expression_ptr);

--- a/ext/liquid_c/variable.c
+++ b/ext/liquid_c/variable.c
@@ -171,14 +171,14 @@ static VALUE variable_strict_parse_method(VALUE self, VALUE markup)
 }
 
 typedef struct {
-    VALUE self;
+    expression_t *expression;
     VALUE context;
 } variable_expression_evaluate_args_t;
 
 static VALUE try_variable_expression_evaluate(VALUE uncast_args)
 {
     variable_expression_evaluate_args_t *args = (void *)uncast_args;
-    return expression_evaluate(args->self, args->context);
+    return liquid_vm_evaluate(args->context, &args->expression->code);
 }
 
 static VALUE rescue_variable_expression_evaluate(VALUE uncast_args, VALUE exception)
@@ -189,10 +189,17 @@ static VALUE rescue_variable_expression_evaluate(VALUE uncast_args, VALUE except
     rb_exc_raise(exception);
 }
 
-static VALUE variable_expression_evaluate(VALUE self, VALUE context)
+VALUE internal_variable_expression_evaluate(expression_t *expression, VALUE context)
 {
-    variable_expression_evaluate_args_t args = { self, context };
+    variable_expression_evaluate_args_t args = { expression, context };
     return rb_rescue(try_variable_expression_evaluate, (VALUE)&args, rescue_variable_expression_evaluate, (VALUE)&args);
+}
+
+static VALUE variable_expression_evaluate_method(VALUE self, VALUE context)
+{
+    expression_t *expression;
+    Expression_Get_Struct(self, expression);
+    return internal_variable_expression_evaluate(expression, context);
 }
 
 void init_liquid_variable(void)
@@ -211,6 +218,6 @@ void init_liquid_variable(void)
 
     cLiquidCVariableExpression = rb_define_class_under(mLiquidC, "VariableExpression", cLiquidCExpression);
     rb_global_variable(&cLiquidCVariableExpression);
-    rb_define_method(cLiquidCVariableExpression, "evaluate", variable_expression_evaluate, 1);
+    rb_define_method(cLiquidCVariableExpression, "evaluate", variable_expression_evaluate_method, 1);
 }
 

--- a/ext/liquid_c/variable.h
+++ b/ext/liquid_c/variable.h
@@ -3,6 +3,7 @@
 
 #include "vm_assembler.h"
 #include "block.h"
+#include "expression.h"
 
 extern VALUE cLiquidCVariableExpression;
 
@@ -17,6 +18,7 @@ typedef struct variable_parse_args {
 void init_liquid_variable(void);
 void internal_variable_compile(variable_parse_args_t *parse_args, unsigned int line_number);
 void internal_variable_compile_evaluate(variable_parse_args_t *parse_args);
+VALUE internal_variable_expression_evaluate(expression_t *expression, VALUE context);
 
 #endif
 

--- a/test/unit/variable_test.rb
+++ b/test/unit/variable_test.rb
@@ -225,6 +225,13 @@ class VariableTest < Minitest::Test
     assert_equal('Liquid error: concat filter requires an array argument', exc.message)
   end
 
+  def test_filter_argument_error_translation
+    variable = Liquid::Variable.new("'some words' | split", Liquid::ParseContext.new)
+    context = Liquid::Context.new
+    exc = assert_raises(Liquid::ArgumentError) { variable.render(context) }
+    assert_equal('Liquid error: wrong number of arguments (given 1, expected 2)', exc.message)
+  end
+
   private
 
   def variable_strict_parse(markup)


### PR DESCRIPTION
## Problem

https://github.com/shopify/liquid-c/pull/115 fixed ArgumentError translation for Liquid::Variable#render, but Liquid::Context#evaluate was still doing a direct function call in C to the implementation of Liquid::C::Expression#evaluate.  As a result, the error was still not being translated properly.

## Solution

The first commit refactors the variable expression evaluation to provide an internal_variable_expression_evaluate function for context.c.

The second commit fixes the bug by checking the class in context_evaluate to call internal_variable_expression_evaluate for a cLiquidCVariableExpression.