### PR TITLE
Fix missing cleanup of parse context after a syntax error 

### DIFF
--- a/ext/liquid_c/block.c
+++ b/ext/liquid_c/block.c
@@ -310,6 +310,7 @@ static VALUE block_body_freeze(VALUE self)
 
     VALUE parse_context = body->as.intermediate.parse_context;
     VALUE document_body = parse_context_get_document_body(parse_context);
+    rb_check_frozen(document_body);
 
     vm_assembler_pool_t *assembler_pool = body->as.intermediate.vm_assembler_pool;
     vm_assembler_t *assembler = body->as.intermediate.code;
@@ -335,6 +336,7 @@ static VALUE block_body_render_to_output_buffer(VALUE self, VALUE context, VALUE
     BlockBody_Get_Struct(self, body);
     ensure_body_compiled(body);
     document_body_entry_t *entry = &body->as.compiled.document_body_entry;
+    document_body_ensure_compile_finished(entry->body);
 
     liquid_vm_render(document_body_get_block_body_header_ptr(entry), document_body_get_constants_ptr(entry), context, output);
     return output;

--- a/ext/liquid_c/block.h
+++ b/ext/liquid_c/block.h
@@ -17,7 +17,6 @@ typedef struct block_body {
             VALUE parse_context;
             vm_assembler_pool_t *vm_assembler_pool;
             bool blank;
-            bool root;
             unsigned int render_score;
             vm_assembler_t *code;
         } intermediate;

--- a/ext/liquid_c/document_body.c
+++ b/ext/liquid_c/document_body.c
@@ -52,6 +52,8 @@ VALUE document_body_new_instance()
 
 void document_body_write_block_body(VALUE self, bool blank, uint32_t render_score, vm_assembler_t *code, document_body_entry_t *entry)
 {
+    assert(!RB_OBJ_FROZEN(self));
+
     document_body_t *body;
     DocumentBody_Get_Struct(self, body);
 

--- a/ext/liquid_c/document_body.h
+++ b/ext/liquid_c/document_body.h
@@ -49,4 +49,11 @@ static inline const VALUE *document_body_get_constants_ptr(const document_body_e
     return RARRAY_PTR(entry->body->constants) + header->constants_offset;
 }
 
+static inline void document_body_ensure_compile_finished(document_body_t *body)
+{
+    if (RB_UNLIKELY(!RB_OBJ_FROZEN(body->self))) {
+        rb_raise(rb_eRuntimeError, "Liquid document hasn't finished compilation");
+    }
+}
+
 #endif

--- a/ext/liquid_c/parse_context.c
+++ b/ext/liquid_c/parse_context.c
@@ -3,15 +3,13 @@
 
 static ID id_document_body, id_vm_assembler_pool;
 
-bool parse_context_document_body_initialized_p(VALUE self)
+static bool parse_context_document_body_initialized_p(VALUE self)
 {
     return RTEST(rb_attr_get(self, id_document_body));
 }
 
-void parse_context_init_document_body(VALUE self)
+static void parse_context_init_document_body(VALUE self)
 {
-    assert(!parse_context_document_body_initialized_p(self));
-
     VALUE document_body = document_body_new_instance();
     rb_ivar_set(self, id_document_body, document_body);
 }
@@ -22,14 +20,6 @@ VALUE parse_context_get_document_body(VALUE self)
 
     return rb_ivar_get(self, id_document_body);
 }
-
-void parse_context_remove_document_body(VALUE self)
-{
-    assert(parse_context_document_body_initialized_p(self));
-
-    rb_ivar_set(self, id_document_body, Qnil);
-}
-
 
 vm_assembler_pool_t *parse_context_init_vm_assembler_pool(VALUE self)
 {
@@ -54,16 +44,29 @@ vm_assembler_pool_t *parse_context_get_vm_assembler_pool(VALUE self)
     return vm_assembler_pool;
 }
 
-void parse_context_remove_vm_assembler_pool(VALUE self)
+static VALUE parse_context_start_liquid_c_parsing(VALUE self)
 {
-    assert(RTEST(rb_attr_get(self, id_vm_assembler_pool)));
-
-    rb_ivar_set(self, id_vm_assembler_pool, Qnil);
+    if (RB_UNLIKELY(parse_context_document_body_initialized_p(self))) {
+        rb_raise(rb_eRuntimeError, "liquid-c parsing already started for this parse context");
+    }
+    parse_context_init_document_body(self);
+    parse_context_init_vm_assembler_pool(self);
+    return Qnil;
 }
 
+static VALUE parse_context_cleanup_liquid_c_parsing(VALUE self)
+{
+    rb_ivar_set(self, id_document_body, Qnil);
+    rb_ivar_set(self, id_vm_assembler_pool, Qnil);
+    return Qnil;
+}
 
 void liquid_define_parse_context()
 {
     id_document_body = rb_intern("document_body");
     id_vm_assembler_pool = rb_intern("vm_assembler_pool");
+
+    VALUE cLiquidParseContext = rb_const_get(mLiquid, rb_intern("ParseContext"));
+    rb_define_method(cLiquidParseContext, "start_liquid_c_parsing", parse_context_start_liquid_c_parsing, 0);
+    rb_define_method(cLiquidParseContext, "cleanup_liquid_c_parsing", parse_context_cleanup_liquid_c_parsing, 0);
 }

--- a/ext/liquid_c/parse_context.c
+++ b/ext/liquid_c/parse_context.c
@@ -56,6 +56,7 @@ static VALUE parse_context_start_liquid_c_parsing(VALUE self)
 
 static VALUE parse_context_cleanup_liquid_c_parsing(VALUE self)
 {
+    rb_obj_freeze(rb_ivar_get(self, id_document_body));
     rb_ivar_set(self, id_document_body, Qnil);
     rb_ivar_set(self, id_vm_assembler_pool, Qnil);
     return Qnil;

--- a/ext/liquid_c/parse_context.h
+++ b/ext/liquid_c/parse_context.h
@@ -6,13 +6,8 @@
 #include "vm_assembler_pool.h"
 
 void liquid_define_parse_context();
-bool parse_context_document_body_initialized_p(VALUE self);
-void parse_context_init_document_body(VALUE self);
 VALUE parse_context_get_document_body(VALUE self);
-void parse_context_remove_document_body(VALUE self);
 
-vm_assembler_pool_t *parse_context_init_vm_assembler_pool(VALUE self);
 vm_assembler_pool_t *parse_context_get_vm_assembler_pool(VALUE self);
-void parse_context_remove_vm_assembler_pool(VALUE self);
 
 #endif

--- a/lib/liquid/c.rb
+++ b/lib/liquid/c.rb
@@ -102,11 +102,21 @@ module Liquid
   module C
     module DocumentClassPatch
       def parse(tokenizer, parse_context)
-        if tokenizer.is_a?(Liquid::C::Tokenizer) && parse_context[:bug_compatible_whitespace_trimming]
-          # Temporary to test rollout of the fix for this bug
-          tokenizer.bug_compatible_whitespace_trimming!
+        if tokenizer.is_a?(Liquid::C::Tokenizer)
+          if parse_context[:bug_compatible_whitespace_trimming]
+            # Temporary to test rollout of the fix for this bug
+            tokenizer.bug_compatible_whitespace_trimming!
+          end
+
+          begin
+            parse_context.start_liquid_c_parsing
+            super
+          ensure
+            parse_context.cleanup_liquid_c_parsing
+          end
+        else
+          super
         end
-        super
       end
     end
     Liquid::Document.singleton_class.prepend(DocumentClassPatch)


### PR DESCRIPTION
## Problem

Pull request #102 introduced a memory safety regression that can be reproduced using the following script, where valgrind can be used to detect the read after free

```
require 'liquid/c'

StubFileSystem = Struct.new(partials) do
  def read_template_file(template_path)
    partials.fetch(template_path)
  end
end

Liquid::Template.file_system = StubFileSystem.new(
  'invalid' => "{%%}",
  'a' => '{% include "b" %}',
  'b' => '...',
)

template = Liquid::Template.parse(<<~LIQUID)
  {% include 'invalid' %}
  {% include 'a' %}
LIQUID
puts template.render
```

<details>
  <summary>valgrind error</summary>

```
Invalid read of size 1
   at 0xB7C36E6: vm_render_until_error (vm.c:241)
   by 0x138650: rb_vrescue2 (eval.c:990)
   by 0x13886D: rb_rescue2 (eval.c:967)
   by 0xB7C4375: liquid_vm_render (vm.c:550)
   by 0xB7BB045: block_body_render_to_output_buffer (block.c:355)
   by 0x2F572F: vm_call_cfunc_with_frame (vm_insnhelper.c:2514)
   by 0x2F572F: vm_call_cfunc (vm_insnhelper.c:2539)
   by 0x30D3C6: vm_sendish (vm_insnhelper.c:4023)
   by 0x30D3C6: vm_exec_core (insns.def:801)
   by 0x2FFBC3: rb_vm_exec (vm.c:1920)
   by 0x30523D: vm_call0_body (vm_eval.c:136)
   by 0x30798C: rb_vm_call0 (vm_eval.c:52)
   by 0x30798C: rb_vm_call_kw (vm_eval.c:268)
   by 0x30798C: rb_call0 (vm_eval.c:392)
   by 0x30855F: rb_call (vm_eval.c:718)
   by 0x30855F: rb_funcall (vm_eval.c:942)
   by 0xB7C3C87: vm_render_until_error (vm.c:364)
 Address 0x9043b31 is 33 bytes inside a block of size 64 free'd
   at 0x483DFAF: realloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0x15DC3E: objspace_xrealloc (gc.c:9932)
   by 0x15DC3E: ruby_sized_xrealloc (gc.c:10133)
   by 0x15DC3E: ruby_xrealloc_body (gc.c:10139)
   by 0x15DC3E: ruby_xrealloc (gc.c:12014)
   by 0xB7BBC7F: c_buffer_expand_for_write (c_buffer.c:14)
   by 0xB7BBD6C: c_buffer_reserve_for_write (c_buffer.c:33)
   by 0xB7BCF17: c_buffer_extend_for_write (c_buffer.h:49)
   by 0xB7BD1B1: document_body_write_block_body (document_body.c:66)
   by 0xB7BAF5E: block_body_freeze (block.c:332)
   by 0x2F572F: vm_call_cfunc_with_frame (vm_insnhelper.c:2514)
   by 0x2F572F: vm_call_cfunc (vm_insnhelper.c:2539)
   by 0x30D3C6: vm_sendish (vm_insnhelper.c:4023)
   by 0x30D3C6: vm_exec_core (insns.def:801)
   by 0x2FFBC3: rb_vm_exec (vm.c:1920)
   by 0x30523D: vm_call0_body (vm_eval.c:136)
   by 0x30798C: rb_vm_call0 (vm_eval.c:52)
   by 0x30798C: rb_vm_call_kw (vm_eval.c:268)
   by 0x30798C: rb_call0 (vm_eval.c:392)
 Block was alloc'd at
   at 0x483DFAF: realloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0x15DC3E: objspace_xrealloc (gc.c:9932)
   by 0x15DC3E: ruby_sized_xrealloc (gc.c:10133)
   by 0x15DC3E: ruby_xrealloc_body (gc.c:10139)
   by 0x15DC3E: ruby_xrealloc (gc.c:12014)
   by 0xB7BBC7F: c_buffer_expand_for_write (c_buffer.c:14)
   by 0xB7BBD6C: c_buffer_reserve_for_write (c_buffer.c:33)
   by 0xB7BBD9A: c_buffer_write (c_buffer.c:39)
   by 0xB7BCF75: c_buffer_concat (c_buffer.h:73)
   by 0xB7BD24C: document_body_write_block_body (document_body.c:76)
   by 0xB7BAF5E: block_body_freeze (block.c:332)
   by 0x2F572F: vm_call_cfunc_with_frame (vm_insnhelper.c:2514)
   by 0x2F572F: vm_call_cfunc (vm_insnhelper.c:2539)
   by 0x30D3C6: vm_sendish (vm_insnhelper.c:4023)
   by 0x30D3C6: vm_exec_core (insns.def:801)
   by 0x2FFBC3: rb_vm_exec (vm.c:1920)
   by 0x30523D: vm_call0_body (vm_eval.c:136)
```

</details>

What is happening is that the first included partial has a syntax error, which leaves the document body on the parse context.  As a result, the following two partials get compiled into the same document body, where the include of the last partial ('b') results in the document body being instruction buffer being reallocated to expand it for the write, meaning the rendering of partial 'a' continues by reading from the freed instructions memory allocation.

## Solution

I used an ensure block to cleanup the parse context, so we avoid trying to re-use the document body across templates.

This means we should also have a check to make sure we aren't rendering a block before the document body is finished being compiled, so this PR freezes the document body object and checks for it before rendering it.

I also turned the reproduction script into a test so that there is a test for this code path.