### PR TITLE
Provide test/liquid_test_helper to make it easier to run specific liquid tests

### DIFF
--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -1,18 +1,9 @@
 # frozen_string_literal: true
-liquid_lib_dir = $LOAD_PATH.detect { |p| File.exist?(File.join(p, 'liquid.rb')) }
-liquid_test_dir = File.join(File.dirname(liquid_lib_dir), 'test')
-$LOAD_PATH << liquid_test_dir
 
-require 'test_helper'
-require 'liquid/c'
+require_relative 'liquid_test_helper'
 
-if ENV['LIQUID_C_DISABLE_VM']
-  puts "-- Liquid-C VM Disabled"
-  Liquid::ParseContext.liquid_c_nodes_disabled = true
-end
-
-test_files = Dir[File.join(liquid_test_dir, 'integration/**/*_test.rb')]
-test_files << File.join(liquid_test_dir, 'unit/tokenizer_unit_test.rb')
+test_files = Dir[File.join(LIQUID_TEST_DIR, 'integration/**/*_test.rb')]
+test_files << File.join(LIQUID_TEST_DIR, 'unit/tokenizer_unit_test.rb')
 test_files.each do |test_file|
   require test_file
 end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -11,7 +11,7 @@ if ENV['LIQUID_C_DISABLE_VM']
   Liquid::ParseContext.liquid_c_nodes_disabled = true
 end
 
-test_files = FileList[File.join(liquid_test_dir, 'integration/**/*_test.rb')]
+test_files = Dir[File.join(liquid_test_dir, 'integration/**/*_test.rb')]
 test_files << File.join(liquid_test_dir, 'unit/tokenizer_unit_test.rb')
 test_files.each do |test_file|
   require test_file

--- a/test/liquid_test_helper.rb
+++ b/test/liquid_test_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# This can be used to setup for running tests from the liquid test suite.
+# For example, you could run a single liquid test as follows:
+# $ ruby -r./test/liquid_test_helper `bundle info liquid --path`/test/integration/template_test.rb
+
+require 'bundler/setup'
+
+liquid_lib_dir = $LOAD_PATH.detect { |p| File.exist?(File.join(p, 'liquid.rb')) }
+LIQUID_TEST_DIR = File.join(File.dirname(liquid_lib_dir), 'test')
+$LOAD_PATH << LIQUID_TEST_DIR << File.expand_path('../lib', __dir__)
+
+require 'test_helper'
+require 'liquid/c'
+
+if ENV['LIQUID_C_DISABLE_VM']
+  puts "-- Liquid-C VM Disabled"
+  Liquid::ParseContext.liquid_c_nodes_disabled = true
+end


### PR DESCRIPTION
## Problem

When there are integration test failures, it can be a bit awkward to run a specific test in the liquid test suite.  It isn't as simple as using `bundle exec ruby -Itest`, since the load path must be setup with both the liquid repo's test path and the liquid-c repo's lib path.

## Solution

Extract the setup for test/integration_test.rb into a test/liquid_test_helper file so that it can be required to do this setup.  It can be used to run a specific test using `ruby -r./test/liquid_test_helper` followed by the test file and any minitest arguments.

For example:
```
ruby -r./test/liquid_test_helper `bundle info liquid --path`/test/integration/template_test.rb
```