### PR TITLE
Return document body entry from document_body_write_block_body

### DIFF
--- a/ext/liquid_c/block.c
+++ b/ext/liquid_c/block.c
@@ -317,9 +317,9 @@ static VALUE block_body_freeze(VALUE self)
     bool blank = body->as.intermediate.blank;
     uint32_t render_score = body->as.intermediate.render_score;
     vm_assembler_t *code = body->as.intermediate.code;
-    body->compiled = true;
+    body->as.compiled.document_body_entry = document_body_write_block_body(document_body, blank, render_score, code);
     body->as.compiled.nodelist = Qundef;
-    document_body_write_block_body(document_body, blank, render_score, code, &body->as.compiled.document_body_entry);
+    body->compiled = true;
     vm_assembler_pool_recycle_assembler(assembler_pool, assembler);
 
     rb_call_super(0, NULL);

--- a/ext/liquid_c/document_body.c
+++ b/ext/liquid_c/document_body.c
@@ -50,7 +50,7 @@ VALUE document_body_new_instance()
     return rb_class_new_instance(0, NULL, cLiquidCDocumentBody);
 }
 
-void document_body_write_block_body(VALUE self, bool blank, uint32_t render_score, vm_assembler_t *code, document_body_entry_t *entry)
+document_body_entry_t document_body_write_block_body(VALUE self, bool blank, uint32_t render_score, vm_assembler_t *code)
 {
     assert(!RB_OBJ_FROZEN(self));
 
@@ -59,8 +59,7 @@ void document_body_write_block_body(VALUE self, bool blank, uint32_t render_scor
 
     c_buffer_zero_pad_for_alignment(&body->buffer, alignof(block_body_header_t));
 
-    entry->body = body;
-    entry->buffer_offset = c_buffer_size(&body->buffer);
+    size_t buffer_offset = c_buffer_size(&body->buffer);
 
     assert(c_buffer_size(&code->constants) % sizeof(VALUE) == 0);
     uint32_t constants_len = (uint32_t)(c_buffer_size(&code->constants) / sizeof(VALUE));
@@ -78,6 +77,8 @@ void document_body_write_block_body(VALUE self, bool blank, uint32_t render_scor
     c_buffer_concat(&body->buffer, &code->instructions);
 
     rb_ary_cat(body->constants, (VALUE *)code->constants.data, constants_len);
+
+    return (document_body_entry_t) { .body = body, .buffer_offset = buffer_offset };
 }
 
 void liquid_define_document_body()

--- a/ext/liquid_c/document_body.h
+++ b/ext/liquid_c/document_body.h
@@ -30,7 +30,7 @@ typedef struct document_body_entry {
 
 void liquid_define_document_body();
 VALUE document_body_new_instance();
-void document_body_write_block_body(VALUE self, bool blank, uint32_t render_score, vm_assembler_t *code, document_body_entry_t *entry);
+document_body_entry_t document_body_write_block_body(VALUE self, bool blank, uint32_t render_score, vm_assembler_t *code);
 
 static inline void document_body_entry_mark(document_body_entry_t *entry)
 {


### PR DESCRIPTION
Depends on https://github.com/Shopify/liquid-c/pull/145

In https://github.com/Shopify/liquid-c/pull/145, I was considering adding a `rb_check_frozen(document_body);` check into `document_body_write_block_body` but realized an exception in the function would leave the block body in an bad state, since it was in the middle of changing the union from the intermediate to the compiled state.

In order to avoid this type of problem, which is theoretically also possible on out of memory exceptions, we can instead return the document_body_entry_t so that the block body struct can have its union changed all at once after document_body_write_block_body returns.