### PR TITLE
Add a GC stress test as a regression test for the bug fixed by #147

### DIFF
--- a/test/liquid_test_helper.rb
+++ b/test/liquid_test_helper.rb
@@ -17,3 +17,5 @@ if ENV['LIQUID_C_DISABLE_VM']
   puts "-- Liquid-C VM Disabled"
   Liquid::ParseContext.liquid_c_nodes_disabled = true
 end
+
+GC.stress = true if ENV['GC_STRESS']

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,3 +7,5 @@ if GC.respond_to?(:verify_compaction_references)
   # move objects around, helping to find object movement bugs.
   GC.verify_compaction_references(double_heap: true, toward: :empty)
 end
+
+GC.stress = true if ENV['GC_STRESS']

--- a/test/unit/gc_stress_test.rb
+++ b/test/unit/gc_stress_test.rb
@@ -16,9 +16,12 @@ class GCStressTest < Minitest::Test
   private
 
   def gc_stress
+    old_value = GC.stress
     GC.stress = true
-    yield
-  ensure
-    GC.stress = false
+    begin
+      yield
+    ensure
+      GC.stress = old_value
+    end
   end
 end

--- a/test/unit/gc_stress_test.rb
+++ b/test/unit/gc_stress_test.rb
@@ -1,0 +1,24 @@
+# encoding: utf-8
+# frozen_string_literal: true
+require 'test_helper'
+
+# Help catch bugs from objects not being marked at all
+# GC opportunities.
+class GCStressTest < Minitest::Test
+  def test_compile_and_render
+    source = '{% assign x = 1 %}{% if x -%} x: {{ x | plus: 2 }}{% endif %}'
+    result = gc_stress do
+      Liquid::Template.parse(source).render!
+    end
+    assert_equal("x: 3", result)
+  end
+
+  private
+
+  def gc_stress
+    GC.stress = true
+    yield
+  ensure
+    GC.stress = false
+  end
+end


### PR DESCRIPTION
## Problem

https://github.com/Shopify/liquid-c/pull/147 fixed a crash that can occur when the GC starts within a specific function and didn't provide a regression test to catch a future bug in the same place.

## Solution

Add a test that uses `GC.stress=` to reliably reproduce that crash, while also providing some coverage for this sort of bug on some common code paths (parsing and rendering a tag, variable, block, filter and raw text).