### PR TITLE
Respect disable_liquid_c_nodes when parsing expressions

### DIFF
--- a/ext/liquid_c/expression.c
+++ b/ext/liquid_c/expression.c
@@ -62,6 +62,9 @@ static VALUE internal_expression_parse(parser_t *p)
 
 static VALUE expression_strict_parse(VALUE klass, VALUE markup)
 {
+    if (NIL_P(markup))
+        return Qnil;
+
     StringValue(markup);
     char *start = RSTRING_PTR(markup);
 

--- a/test/unit/expression_test.rb
+++ b/test/unit/expression_test.rb
@@ -157,6 +157,18 @@ class ExpressionTest < MiniTest::Test
     ASM
   end
 
+  def test_disable_c_nodes
+    context = Liquid::Context.new({ "x" => 123 })
+
+    expr = Liquid::ParseContext.new.parse_expression('x')
+    assert_instance_of(Liquid::C::Expression, expr)
+    assert_equal(123, context.evaluate(expr))
+
+    expr = Liquid::ParseContext.new(disable_liquid_c_nodes: true).parse_expression('x')
+    assert_instance_of(Liquid::VariableLookup, expr)
+    assert_equal(123, context.evaluate(expr))
+  end
+
   private
 
   class ReturnKeyDrop < Liquid::Drop


### PR DESCRIPTION
@samdoiron pointed out that I hadn't gotten around to having expression parsing respect the `disable_liquid_c_nodes: true` parse option.  This can be problematic when parsing liquid for some type of static analysis in the same program that also uses liquid-c, since it prevents liquid-c from being dynamically disabled just for that static analysis.

I had already made the necessary change to liquid in https://github.com/shopify/liquid/pull/1333 so that expressions could be parsed through the parse context.  This PR makes the corresponding liquid-c change that overrides Liquid::ParseContext#parse_expression to make using Liquid::C::Expression conditional on the presence of the `disable_liquid_c_nodes` parse option.