### PR TITLE
Fix memory leak for filters with keyword arguments

### DIFF
--- a/ext/liquid_c/variable.c
+++ b/ext/liquid_c/variable.c
@@ -72,10 +72,7 @@ static VALUE try_variable_strict_parse(VALUE uncast_args)
             vm_assembler_concat(code, push_keywords_code);
             vm_assembler_add_hash_new(code, keyword_arg_count);
 
-            // There are no external references to this temporary object, so we can eagerly free it
-            DATA_PTR(push_keywords_obj) = NULL;
-            vm_assembler_free(push_keywords_code);
-            rb_gc_force_recycle(push_keywords_obj); // also acts as a RB_GC_GUARD(push_keywords_obj);
+            RB_GC_GUARD(push_keywords_obj);
         }
         vm_assembler_add_filter(code, filter_name, arg_count);
     }


### PR DESCRIPTION
The `push_keywords_obj` (which is a TypedData object) has its data pointer set to NULL and is never freed, which leaks memory. The following script demonstrates the issue:

```ruby
require "liquid"
require_relative "lib/liquid/c"

1_000_000.times do
  Liquid::Template.parse("{{ value | default: 'None', allow_false: true }}")
end

puts `ps -o rss -p #{$$}`.chomp.split("\n").last.to_i
```

Before this patch, the output is `199620`, after this patch, the output is `124160`.

We shouldn't be using `rb_gc_force_recycle` anyways because it doesn't clean up resources and we should let the GC decide when to free objects (rather than forcing the GC to reclaim the object).