### PR TITLE
Fix memory leak for filters with keyword arguments

### DIFF
--- a/ext/liquid_c/expression.c
+++ b/ext/liquid_c/expression.c
@@ -12,7 +12,7 @@ static void expression_mark(void *ptr)
     vm_assembler_gc_mark(&expression->code);
 }
 
-static void expression_free(void *ptr)
+void expression_free(void *ptr)
 {
     expression_t *expression = ptr;
     vm_assembler_free(&expression->code);

--- a/ext/liquid_c/expression.h
+++ b/ext/liquid_c/expression.h
@@ -16,6 +16,7 @@ extern const rb_data_type_t expression_data_type;
 
 void liquid_define_expression();
 
+void expression_free(void *ptr);
 VALUE expression_new(VALUE klass, expression_t **expression_ptr);
 VALUE expression_evaluate(VALUE self, VALUE context);
 VALUE internal_expression_evaluate(expression_t *expression, VALUE context);

--- a/ext/liquid_c/variable.c
+++ b/ext/liquid_c/variable.c
@@ -73,8 +73,8 @@ static VALUE try_variable_strict_parse(VALUE uncast_args)
             vm_assembler_add_hash_new(code, keyword_arg_count);
 
             // There are no external references to this temporary object, so we can eagerly free it
+            expression_free(DATA_PTR(push_keywords_obj));
             DATA_PTR(push_keywords_obj) = NULL;
-            vm_assembler_free(push_keywords_code);
             rb_gc_force_recycle(push_keywords_obj); // also acts as a RB_GC_GUARD(push_keywords_obj);
         }
         vm_assembler_add_filter(code, filter_name, arg_count);


### PR DESCRIPTION
Alternative to https://github.com/Shopify/liquid-c/pull/157 (see that PR for a description of the problem)
Closes #157

This differs from that PR in that it eagerly frees the memory to reduce garbage collection.

I tested with the script from https://github.com/Shopify/liquid-c/pull/157 and it actually resulted in a lower RSS:
* 3 runs with this branch:
  * 124832
  * 124724
  * 124924
* on the https://github.com/Shopify/liquid-c/pull/157 branch
  * 130264
  * 131428
  * 130488
* on the master branch, for reference
  * 204172