### PR TITLE
Do not use liquid-c when using fallback parsing

### DIFF
--- a/lib/liquid/c.rb
+++ b/lib/liquid/c.rb
@@ -122,6 +122,8 @@ module Liquid
             parse_context.cleanup_liquid_c_parsing
           end
         else
+          parse_context.instance_variable_set(:@liquid_c_nodes_disabled, true)
+
           super
         end
       end

--- a/test/unit/block_test.rb
+++ b/test/unit/block_test.rb
@@ -31,6 +31,11 @@ class BlockTest < MiniTest::Test
     assert_equal(source, template.render!)
   end
 
+  def test_liquid_parse_context_fallback
+    parse_context = Liquid::ParseContext.new
+    Liquid::Document.parse(Liquid::Tokenizer.new("", true), parse_context)
+  end
+
   # Test for bug: https://github.com/Shopify/liquid-c/pull/120
   def test_bug_120_instrument
     calls = []


### PR DESCRIPTION
Using a liquid (Ruby, non-c) tokenizer falls back to liquid to parse, we should set liquid_c_nodes_disabled on the ParseContext to ensure that nothing is parsed through liquid-c.