### PR TITLE
Make BlockBody safe to GC when initialize raises

### DIFF
--- a/ext/liquid_c/block.c
+++ b/ext/liquid_c/block.c
@@ -58,7 +58,7 @@ static void block_body_mark(void *ptr)
 static void block_body_free(void *ptr)
 {
     block_body_t *body = ptr;
-    if (!body->compiled) {
+    if (!body->compiled && body->as.intermediate.code) {
         // Free the assembler instead of recycling it because the vm_assembler_pool may have been GC'd
         vm_assembler_pool_free_assembler(body->as.intermediate.code);
     }

--- a/ext/liquid_c/parse_context.c
+++ b/ext/liquid_c/parse_context.c
@@ -36,9 +36,12 @@ vm_assembler_pool_t *parse_context_init_vm_assembler_pool(VALUE self)
 
 vm_assembler_pool_t *parse_context_get_vm_assembler_pool(VALUE self)
 {
-    assert(RTEST(rb_attr_get(self, id_vm_assembler_pool)));
-
     VALUE obj = rb_ivar_get(self, id_vm_assembler_pool);
+
+    if (obj == Qnil) {
+        rb_raise(rb_eRuntimeError, "Liquid::ParseContext#start_liquid_c_parsing has not yet been called");
+    }
+
     vm_assembler_pool_t *vm_assembler_pool;
     VMAssemblerPool_Get_Struct(obj, vm_assembler_pool);
     return vm_assembler_pool;

--- a/test/unit/block_test.rb
+++ b/test/unit/block_test.rb
@@ -31,6 +31,13 @@ class BlockTest < MiniTest::Test
     assert_equal(source, template.render!)
   end
 
+  def test_raise_for_non_c_parse_context
+    parse_context = Liquid::ParseContext.new
+    assert_raises(RuntimeError) do
+      Liquid::C::BlockBody.new(parse_context)
+    end
+  end
+
   # Test for bug: https://github.com/Shopify/liquid-c/pull/120
   def test_bug_120_instrument
     calls = []


### PR DESCRIPTION
Alternate solution from discussions in #159.

BlockBody segfaults during GC because `body->as.intermediate.code` is null because it raises before any value is set to it.