### PR TITLE
Fix memory leak in the VM assembler

### DIFF
--- a/ext/liquid_c/vm_assembler_pool.c
+++ b/ext/liquid_c/vm_assembler_pool.c
@@ -15,7 +15,9 @@ static void vm_assembler_pool_free(void *ptr)
     vm_assembler_element_t *element = pool->freelist;
     while (element) {
         vm_assembler_free(&element->vm_assembler);
-        element = element->next;
+        vm_assembler_element_t *next = element->next;
+        xfree(element);
+        element = next;
     }
 
     xfree(pool);


### PR DESCRIPTION
The `vm_assembler_element_t` is not freed when the `vm_assembler_pool_t` is freed. This causes a memory leak to occur.

This script demonstrates the issue.

```ruby
require "liquid"
require_relative "lib/liquid/c"

1_000_000.times do |i|
  Liquid::Template.parse("{{ value | default: 'None', allow_false: true }}")
end

puts `ps -o rss -p #{$$}`.chomp.split("\n").last.to_i
```

Before this patch: `124824`

After this patch: `31116`