### PR TITLE
upgrade rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ AllCops:
   TargetRubyVersion: 2.5
   Exclude:
     - 'vendor/bundle/**/*'
+    - 'tmp/**/*'
 
 Style/GlobalVars:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -1,22 +1,23 @@
 # frozen_string_literal: true
-source 'https://rubygems.org'
+
+source "https://rubygems.org"
 git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
 gemspec
 
-gem 'liquid', github: 'Shopify/liquid', ref: 'master'
+gem "liquid", github: "Shopify/liquid", ref: "master"
 
 group :test do
-  gem 'rubocop', '~> 0.93.1', require: false
-  gem 'rubocop-performance', '~> 1.8.1', require: false
-  gem 'rubocop-shopify', '~> 1.0.6', require: false
-  gem 'spy', '0.4.1'
-  gem 'benchmark-ips'
-  gem 'ruby_memcheck'
+  gem "rubocop", "~> 1.24.1", require: false
+  gem "rubocop-performance", "~> 1.13.2", require: false
+  gem "rubocop-shopify", "~> 2.4.0", require: false
+  gem "spy", "0.4.1"
+  gem "benchmark-ips"
+  gem "ruby_memcheck"
 end
 
 group :development do
-  gem 'byebug'
+  gem "byebug"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,19 +1,20 @@
 # frozen_string_literal: true
-require 'rake'
-require 'rake/testtask'
-require 'bundler/gem_tasks'
-require 'rake/extensiontask'
-require 'benchmark'
-require 'ruby_memcheck'
 
-ENV['DEBUG'] ||= 'true'
+require "rake"
+require "rake/testtask"
+require "bundler/gem_tasks"
+require "rake/extensiontask"
+require "benchmark"
+require "ruby_memcheck"
+
+ENV["DEBUG"] ||= "true"
 
 RubyMemcheck.config(binary_name: "liquid_c")
 
 task default: [:test, :rubocop]
 
-task test: ['test:unit', 'test:integration:all']
+task test: ["test:unit", "test:integration:all"]
 
 namespace :test do
-  task valgrind: ['test:unit:valgrind', 'test:integration:valgrind:all']
+  task valgrind: ["test:unit:valgrind", "test:integration:valgrind:all"]
 end

--- a/ext/liquid_c/extconf.rb
+++ b/ext/liquid_c/extconf.rb
@@ -1,22 +1,23 @@
 # frozen_string_literal: true
-require 'mkmf'
-$CFLAGS << ' -std=c11 -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers'
-append_cflags('-fvisibility=hidden')
+
+require "mkmf"
+$CFLAGS << " -std=c11 -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers"
+append_cflags("-fvisibility=hidden")
 # In Ruby 2.6 and earlier, the Ruby headers did not have struct timespec defined
-valid_headers = RbConfig::CONFIG['host_os'] !~ /linux/ || Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7")
-pedantic = !ENV['LIQUID_C_PEDANTIC'].to_s.empty?
+valid_headers = RbConfig::CONFIG["host_os"] !~ /linux/ || Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7")
+pedantic = !ENV["LIQUID_C_PEDANTIC"].to_s.empty?
 if pedantic && valid_headers
-  $CFLAGS << ' -Werror'
+  $CFLAGS << " -Werror"
 end
-if ENV['DEBUG'] == 'true'
-  append_cflags('-fbounds-check')
-  CONFIG['optflags'] = ' -O0'
+if ENV["DEBUG"] == "true"
+  append_cflags("-fbounds-check")
+  CONFIG["optflags"] = " -O0"
 else
-  $CFLAGS << ' -DNDEBUG'
+  $CFLAGS << " -DNDEBUG"
 end
 
 if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7.0") # added in 2.7
-  $CFLAGS << ' -DHAVE_RB_HASH_BULK_INSERT'
+  $CFLAGS << " -DHAVE_RB_HASH_BULK_INSERT"
 end
 
 $warnflags&.gsub!(/-Wdeclaration-after-statement/, "")

--- a/lib/liquid/c.rb
+++ b/lib/liquid/c.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-require 'liquid/c/version'
-require 'liquid'
-require 'liquid_c'
-require 'liquid/c/compile_ext'
+require "liquid/c/version"
+require "liquid"
+require "liquid_c"
+require "liquid/c/compile_ext"
 
 Liquid::C::BlockBody.class_eval do
   def render(context)
-    render_to_output_buffer(context, +'')
+    render_to_output_buffer(context, +"")
   end
 end
 

--- a/liquid-c.gemspec
+++ b/liquid-c.gemspec
@@ -1,8 +1,11 @@
 # coding: utf-8
 # frozen_string_literal: true
-lib = File.expand_path('../lib', __FILE__)
+
+# rubocop:disable Gemspec/RubyVersionGlobalsUsage
+
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'liquid/c/version'
+require "liquid/c/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "liquid-c"
@@ -13,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/shopify/liquid-c"
   spec.license       = "MIT"
 
-  spec.extensions    = ['ext/liquid_c/extconf.rb']
+  spec.extensions    = ["ext/liquid_c/extconf.rb"]
   spec.files         = %x(git ls-files -z).split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
@@ -21,11 +24,11 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.5.0"
 
-  spec.add_dependency('liquid', '>= 5.0.1')
+  spec.add_dependency("liquid", ">= 5.0.1")
 
-  spec.add_development_dependency('bundler', ">= 1.5") # has bugfix for segfaulting deploys
+  spec.add_development_dependency("bundler", ">= 1.5") # has bugfix for segfaulting deploys
+  spec.add_development_dependency("minitest")
   spec.add_development_dependency("rake")
-  spec.add_development_dependency('rake-compiler')
-  spec.add_development_dependency('minitest')
-  spec.add_development_dependency('stackprof') if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.1.0")
+  spec.add_development_dependency("rake-compiler")
+  spec.add_development_dependency("stackprof") if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.1.0")
 end

--- a/performance.rb
+++ b/performance.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
-require 'liquid'
-require 'liquid/c' if ARGV.shift == "c"
-liquid_lib_dir = $LOAD_PATH.detect { |p| File.exist?(File.join(p, 'liquid.rb')) }
+
+require "liquid"
+require "liquid/c" if ARGV.shift == "c"
+liquid_lib_dir = $LOAD_PATH.detect { |p| File.exist?(File.join(p, "liquid.rb")) }
 
 (script = ARGV.shift) || abort("unspecified performance script")
 require File.join(File.dirname(liquid_lib_dir), "performance/#{script}")

--- a/performance/c_profile.rb
+++ b/performance/c_profile.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require 'liquid'
-require 'liquid/c'
-liquid_lib_dir = $LOAD_PATH.detect { |p| File.exist?(File.join(p, 'liquid.rb')) }
+require "liquid"
+require "liquid/c"
+liquid_lib_dir = $LOAD_PATH.detect { |p| File.exist?(File.join(p, "liquid.rb")) }
 require File.join(File.dirname(liquid_lib_dir), "performance/theme_runner")
 
-TASK_NAMES = %w(run compile render)
-task_name = ARGV.first || 'run'
+TASK_NAMES = ["run", "compile", "render"]
+task_name = ARGV.first || "run"
 unless TASK_NAMES.include?(task_name)
   raise "Unsupported task '#{task_name}' (must be one of #{TASK_NAMES})"
 end

--- a/rakelib/compile.rake
+++ b/rakelib/compile.rake
@@ -3,7 +3,7 @@
 ext_task = Rake::ExtensionTask.new("liquid_c")
 
 # For MacOS, generate debug information that ruby can read
-dsymutil = RbConfig::CONFIG['dsymutil']
+dsymutil = RbConfig::CONFIG["dsymutil"]
 unless dsymutil.to_s.empty?
   ext_lib_path = "lib/#{ext_task.binary}"
   dsym_path = "#{ext_lib_path}.dSYM"
@@ -11,5 +11,5 @@ unless dsymutil.to_s.empty?
   file dsym_path => [ext_lib_path] do
     sh dsymutil, ext_lib_path
   end
-  Rake::Task['compile'].enhance([dsym_path])
+  Rake::Task["compile"].enhance([dsym_path])
 end

--- a/rakelib/integration_test.rake
+++ b/rakelib/integration_test.rake
@@ -2,11 +2,11 @@
 
 namespace :test do
   integration_test_config = lambda do |t|
-    t.libs << 'lib'
-    t.test_files = ['test/integration_test.rb']
+    t.libs << "lib"
+    t.test_files = ["test/integration_test.rb"]
   end
 
-  desc 'run test suite with default parser'
+  desc "run test suite with default parser"
   Rake::TestTask.new(integration: :compile, &integration_test_config)
 
   namespace :integration do
@@ -14,9 +14,9 @@ namespace :test do
       rake_task = Rake::Task[task_name]
 
       [
-        [:lax, { 'LIQUID_PARSER_MODE' => 'lax' }],
-        [:strict, { 'LIQUID_PARSER_MODE' => 'strict' }],
-        [:without_vm, { 'LIQUID_C_DISABLE_VM' => 'true' }],
+        [:lax, { "LIQUID_PARSER_MODE" => "lax" }],
+        [:strict, { "LIQUID_PARSER_MODE" => "strict" }],
+        [:without_vm, { "LIQUID_C_DISABLE_VM" => "true" }],
       ].each do |name, env_vars|
         task(name) do
           old_env_values = ENV.to_hash.slice(*env_vars.keys)
@@ -33,11 +33,11 @@ namespace :test do
       task(all: [:lax, :strict, :without_vm])
     end
 
-    define_env_integration_tests.call('test:integration')
+    define_env_integration_tests.call("test:integration")
 
     RubyMemcheck::TestTask.new(valgrind: :compile, &integration_test_config)
     namespace :valgrind do
-      define_env_integration_tests.call('test:integration:valgrind')
+      define_env_integration_tests.call("test:integration:valgrind")
     end
   end
 end

--- a/rakelib/performance.rake
+++ b/rakelib/performance.rake
@@ -13,7 +13,7 @@ namespace :benchmark do
 end
 
 namespace :c_profile do
-  %i(run compile render).each do |task_name|
+  [:run, :compile, :render].each do |task_name|
     task(task_name) do
       ruby "./performance/c_profile.rb #{task_name}"
     end
@@ -33,7 +33,7 @@ namespace :profile do
 end
 
 namespace :compare do
-  %w(lax warn strict).each do |type|
+  ["lax", "warn", "strict"].each do |type|
     desc "Compare Liquid to Liquid-C in #{type} mode"
     task type.to_sym do
       ruby "./performance.rb bare benchmark #{type}"

--- a/rakelib/rubocop.rake
+++ b/rakelib/rubocop.rake
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 task :rubocop do
-  require 'rubocop/rake_task'
+  require "rubocop/rake_task"
   RuboCop::RakeTask.new
 end

--- a/rakelib/unit_test.rake
+++ b/rakelib/unit_test.rake
@@ -2,8 +2,8 @@
 
 namespace :test do
   unit_test_config = lambda do |t|
-    t.libs << 'lib' << 'test'
-    t.test_files = FileList['test/unit/**/*_test.rb']
+    t.libs << "lib" << "test"
+    t.test_files = FileList["test/unit/**/*_test.rb"]
   end
 
   Rake::TestTask.new(unit: :compile, &unit_test_config)

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -2,10 +2,10 @@
 
 at_exit { GC.start }
 
-require_relative 'liquid_test_helper'
+require_relative "liquid_test_helper"
 
-test_files = Dir[File.join(LIQUID_TEST_DIR, 'integration/**/*_test.rb')]
-test_files << File.join(LIQUID_TEST_DIR, 'unit/tokenizer_unit_test.rb')
+test_files = Dir[File.join(LIQUID_TEST_DIR, "integration/**/*_test.rb")]
+test_files << File.join(LIQUID_TEST_DIR, "unit/tokenizer_unit_test.rb")
 test_files.each do |test_file|
   require test_file
 end

--- a/test/liquid_test_helper.rb
+++ b/test/liquid_test_helper.rb
@@ -4,18 +4,18 @@
 # For example, you could run a single liquid test as follows:
 # $ ruby -r./test/liquid_test_helper `bundle info liquid --path`/test/integration/template_test.rb
 
-require 'bundler/setup'
+require "bundler/setup"
 
-liquid_lib_dir = $LOAD_PATH.detect { |p| File.exist?(File.join(p, 'liquid.rb')) }
-LIQUID_TEST_DIR = File.join(File.dirname(liquid_lib_dir), 'test')
-$LOAD_PATH << LIQUID_TEST_DIR << File.expand_path('../lib', __dir__)
+liquid_lib_dir = $LOAD_PATH.detect { |p| File.exist?(File.join(p, "liquid.rb")) }
+LIQUID_TEST_DIR = File.join(File.dirname(liquid_lib_dir), "test")
+$LOAD_PATH << LIQUID_TEST_DIR << File.expand_path("../lib", __dir__)
 
-require 'test_helper'
-require 'liquid/c'
+require "test_helper"
+require "liquid/c"
 
-if ENV['LIQUID_C_DISABLE_VM']
+if ENV["LIQUID_C_DISABLE_VM"]
   puts "-- Liquid-C VM Disabled"
   Liquid::ParseContext.liquid_c_nodes_disabled = true
 end
 
-GC.stress = true if ENV['GC_STRESS']
+GC.stress = true if ENV["GC_STRESS"]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,8 +2,8 @@
 
 at_exit { GC.start }
 
-require 'minitest/autorun'
-require 'liquid/c'
+require "minitest/autorun"
+require "liquid/c"
 
 if GC.respond_to?(:verify_compaction_references)
   # This method was added in Ruby 3.0.0. Calling it this way asks the GC to
@@ -11,4 +11,4 @@ if GC.respond_to?(:verify_compaction_references)
   GC.verify_compaction_references(double_heap: true, toward: :empty)
 end
 
-GC.stress = true if ENV['GC_STRESS']
+GC.stress = true if ENV["GC_STRESS"]

--- a/test/unit/block_test.rb
+++ b/test/unit/block_test.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-require 'test_helper'
+
+require "test_helper"
 
 class BlockTest < MiniTest::Test
   def test_no_allocation_of_trimmed_strings
@@ -22,7 +23,7 @@ class BlockTest < MiniTest::Test
   def test_write_unicode_characters
     output = String.new(encoding: Encoding::UTF_8)
     template = Liquid::Template.parse("ü{{ unicode_char }}")
-    assert_equal("üñ", template.render!({ 'unicode_char' => 'ñ' }, output: output))
+    assert_equal("üñ", template.render!({ "unicode_char" => "ñ" }, output: output))
   end
 
   def test_op_write_raw_w
@@ -91,7 +92,7 @@ class BlockTest < MiniTest::Test
   def test_exception_renderer_exception
     original_error = Liquid::Error.new("original")
     handler_error = RuntimeError.new("exception handler error")
-    context = Liquid::Context.new('raise_error' => ->(_ctx) { raise(original_error) })
+    context = Liquid::Context.new("raise_error" => ->(_ctx) { raise(original_error) })
     context.exception_renderer = lambda do |exc|
       if exc == original_error
         raise(handler_error)
@@ -115,9 +116,9 @@ class BlockTest < MiniTest::Test
     old_file_system = Liquid::Template.file_system
     begin
       Liquid::Template.file_system = StubFileSystem.new(
-        'invalid' => "{% foo %}",
-        'valid' => '{% include "nested" %}',
-        'nested' => 'valid',
+        "invalid" => "{% foo %}",
+        "valid" => '{% include "nested" %}',
+        "nested" => "valid",
       )
 
       template = Liquid::Template.parse("{% include 'invalid' %},{% include 'valid' %}")

--- a/test/unit/context_test.rb
+++ b/test/unit/context_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
-require 'test_helper'
-require 'bigdecimal'
+
+require "test_helper"
+require "bigdecimal"
 
 class ContextTest < Minitest::Test
   def test_evaluate_works_with_normal_values
@@ -66,7 +67,7 @@ class ContextTest < Minitest::Test
   end
 
   def test_c_filtering_predicate
-    context = Liquid::Context.new({ 'test' => [TestDrop.new] })
+    context = Liquid::Context.new({ "test" => [TestDrop.new] })
     template = Liquid::Template.parse('{{ test[0].is_filtering }},{{ test | map: "is_filtering" }}')
 
     assert_equal("false,true", template.render!(context))

--- a/test/unit/expression_test.rb
+++ b/test/unit/expression_test.rb
@@ -1,45 +1,46 @@
 # frozen_string_literal: true
-require 'test_helper'
+
+require "test_helper"
 
 class ExpressionTest < MiniTest::Test
   def test_constant_literals
-    assert_equal(true, Liquid::C::Expression.strict_parse('true'))
-    assert_equal(false, Liquid::C::Expression.strict_parse('false'))
-    assert_nil(Liquid::C::Expression.strict_parse('nil'))
-    assert_nil(Liquid::C::Expression.strict_parse('null'))
+    assert_equal(true, Liquid::C::Expression.strict_parse("true"))
+    assert_equal(false, Liquid::C::Expression.strict_parse("false"))
+    assert_nil(Liquid::C::Expression.strict_parse("nil"))
+    assert_nil(Liquid::C::Expression.strict_parse("null"))
 
-    empty = Liquid::C::Expression.strict_parse('empty')
-    assert_equal('', empty)
-    assert_same(empty, Liquid::C::Expression.strict_parse('blank'))
+    empty = Liquid::C::Expression.strict_parse("empty")
+    assert_equal("", empty)
+    assert_same(empty, Liquid::C::Expression.strict_parse("blank"))
   end
 
   def test_push_literals
-    assert_nil(compile_and_eval('nil'))
-    assert_equal(true, compile_and_eval('true'))
-    assert_equal(false, compile_and_eval('false'))
+    assert_nil(compile_and_eval("nil"))
+    assert_equal(true, compile_and_eval("true"))
+    assert_equal(false, compile_and_eval("false"))
   end
 
   def test_constant_integer
-    assert_equal(42, Liquid::C::Expression.strict_parse('42'))
+    assert_equal(42, Liquid::C::Expression.strict_parse("42"))
   end
 
   def test_push_int8
-    assert_equal(127, compile_and_eval('127'))
-    assert_equal(-128, compile_and_eval('-128'))
+    assert_equal(127, compile_and_eval("127"))
+    assert_equal(-128, compile_and_eval("-128"))
   end
 
   def test_push_int16
-    assert_equal(128, compile_and_eval('128'))
-    assert_equal(-129, compile_and_eval('-129'))
-    assert_equal(32767, compile_and_eval('32767'))
-    assert_equal(-32768, compile_and_eval('-32768'))
+    assert_equal(128, compile_and_eval("128"))
+    assert_equal(-129, compile_and_eval("-129"))
+    assert_equal(32767, compile_and_eval("32767"))
+    assert_equal(-32768, compile_and_eval("-32768"))
   end
 
   def test_push_large_fixnum
-    assert_equal(32768, compile_and_eval('32768'))
-    assert_equal(-2147483648, compile_and_eval('-2147483648'))
-    assert_equal(2147483648, compile_and_eval('2147483648'))
-    assert_equal(4611686018427387903, compile_and_eval('4611686018427387903'))
+    assert_equal(32768, compile_and_eval("32768"))
+    assert_equal(-2147483648, compile_and_eval("-2147483648"))
+    assert_equal(2147483648, compile_and_eval("2147483648"))
+    assert_equal(4611686018427387903, compile_and_eval("4611686018427387903"))
   end
 
   def test_push_big_int
@@ -48,8 +49,8 @@ class ExpressionTest < MiniTest::Test
   end
 
   def test_float
-    assert_equal(123.4, Liquid::C::Expression.strict_parse('123.4'))
-    assert_equal(-1.5, compile_and_eval('-1.5'))
+    assert_equal(123.4, Liquid::C::Expression.strict_parse("123.4"))
+    assert_equal(-1.5, compile_and_eval("-1.5"))
   end
 
   def test_string
@@ -59,7 +60,7 @@ class ExpressionTest < MiniTest::Test
 
   def test_find_static_variable
     context = Liquid::Context.new({ "x" => 123 })
-    expr = Liquid::C::Expression.strict_parse('x')
+    expr = Liquid::C::Expression.strict_parse("x")
 
     assert_instance_of(Liquid::C::Expression, expr)
     assert_equal(123, context.evaluate(expr))
@@ -67,13 +68,13 @@ class ExpressionTest < MiniTest::Test
 
   def test_find_dynamic_variable
     context = Liquid::Context.new({ "x" => "y", "y" => 42 })
-    expr = Liquid::C::Expression.strict_parse('[x]')
+    expr = Liquid::C::Expression.strict_parse("[x]")
     assert_equal(42, context.evaluate(expr))
   end
 
   def test_find_missing_variable
     context = Liquid::Context.new({})
-    expr = Liquid::C::Expression.strict_parse('missing')
+    expr = Liquid::C::Expression.strict_parse("missing")
 
     assert_nil(context.evaluate(expr))
 
@@ -87,29 +88,29 @@ class ExpressionTest < MiniTest::Test
   def test_lookup_const_key
     context = Liquid::Context.new({ "obj" => { "prop" => "some value" } })
 
-    expr = Liquid::C::Expression.strict_parse('obj.prop')
-    assert_equal('some value', context.evaluate(expr))
+    expr = Liquid::C::Expression.strict_parse("obj.prop")
+    assert_equal("some value", context.evaluate(expr))
 
     expr = Liquid::C::Expression.strict_parse('obj["prop"]')
-    assert_equal('some value', context.evaluate(expr))
+    assert_equal("some value", context.evaluate(expr))
   end
 
   def test_lookup_variable_key
     context = Liquid::Context.new({ "field_name" => "prop", "obj" => { "prop" => "another value" } })
-    expr = Liquid::C::Expression.strict_parse('obj[field_name]')
-    assert_equal('another value', context.evaluate(expr))
+    expr = Liquid::C::Expression.strict_parse("obj[field_name]")
+    assert_equal("another value", context.evaluate(expr))
   end
 
   def test_lookup_command
-    context = Liquid::Context.new({ "ary" => ['a', 'b', 'c'] })
-    assert_equal(3, context.evaluate(Liquid::C::Expression.strict_parse('ary.size')))
-    assert_equal('a', context.evaluate(Liquid::C::Expression.strict_parse('ary.first')))
-    assert_equal('c', context.evaluate(Liquid::C::Expression.strict_parse('ary.last')))
+    context = Liquid::Context.new({ "ary" => ["a", "b", "c"] })
+    assert_equal(3, context.evaluate(Liquid::C::Expression.strict_parse("ary.size")))
+    assert_equal("a", context.evaluate(Liquid::C::Expression.strict_parse("ary.first")))
+    assert_equal("c", context.evaluate(Liquid::C::Expression.strict_parse("ary.last")))
   end
 
   def test_lookup_missing_key
-    context = Liquid::Context.new({ 'obj' => {} })
-    expr = Liquid::C::Expression.strict_parse('obj.missing')
+    context = Liquid::Context.new({ "obj" => {} })
+    expr = Liquid::C::Expression.strict_parse("obj.missing")
 
     assert_nil(context.evaluate(expr))
 
@@ -123,23 +124,23 @@ class ExpressionTest < MiniTest::Test
   def test_lookup_on_var_with_literal_name
     context = Liquid::Context.new({ "blank" => { "x" => "result" } })
 
-    assert_equal("result", context.evaluate(Liquid::C::Expression.strict_parse('blank.x')))
+    assert_equal("result", context.evaluate(Liquid::C::Expression.strict_parse("blank.x")))
     assert_equal("result", context.evaluate(Liquid::C::Expression.strict_parse('blank["x"]')))
   end
 
   def test_const_range
-    assert_equal((1..2), Liquid::C::Expression.strict_parse('(1..2)'))
+    assert_equal((1..2), Liquid::C::Expression.strict_parse("(1..2)"))
   end
 
   def test_dynamic_range
     context = Liquid::Context.new({ "var" => 42 })
-    expr = Liquid::C::Expression.strict_parse('(1..var)')
+    expr = Liquid::C::Expression.strict_parse("(1..var)")
     assert_instance_of(Liquid::C::Expression, expr)
     assert_equal((1..42), context.evaluate(expr))
   end
 
   def test_disassemble
-    expression = Liquid::C::Expression.strict_parse('foo.bar[123]')
+    expression = Liquid::C::Expression.strict_parse("foo.bar[123]")
     assert_equal(<<~ASM, expression.disassemble)
       0x0000: find_static_var("foo")
       0x0001: lookup_const_key("bar")
@@ -150,7 +151,7 @@ class ExpressionTest < MiniTest::Test
   end
 
   def test_disassemble_int16
-    assert_equal(<<~ASM, Liquid::C::Expression.strict_parse('[12345]').disassemble)
+    assert_equal(<<~ASM, Liquid::C::Expression.strict_parse("[12345]").disassemble)
       0x0000: push_int16(12345)
       0x0003: find_var
       0x0004: leave
@@ -160,11 +161,11 @@ class ExpressionTest < MiniTest::Test
   def test_disable_c_nodes
     context = Liquid::Context.new({ "x" => 123 })
 
-    expr = Liquid::ParseContext.new.parse_expression('x')
+    expr = Liquid::ParseContext.new.parse_expression("x")
     assert_instance_of(Liquid::C::Expression, expr)
     assert_equal(123, context.evaluate(expr))
 
-    expr = Liquid::ParseContext.new(disable_liquid_c_nodes: true).parse_expression('x')
+    expr = Liquid::ParseContext.new(disable_liquid_c_nodes: true).parse_expression("x")
     assert_instance_of(Liquid::VariableLookup, expr)
     assert_equal(123, context.evaluate(expr))
   end
@@ -178,7 +179,7 @@ class ExpressionTest < MiniTest::Test
   end
 
   def compile_and_eval(source)
-    context = Liquid::Context.new({ 'ret_key' => ReturnKeyDrop.new })
+    context = Liquid::Context.new({ "ret_key" => ReturnKeyDrop.new })
     expr = Liquid::C::Expression.strict_parse("ret_key[#{source}]")
     context.evaluate(expr)
   end

--- a/test/unit/gc_stress_test.rb
+++ b/test/unit/gc_stress_test.rb
@@ -1,12 +1,13 @@
 # encoding: utf-8
 # frozen_string_literal: true
-require 'test_helper'
+
+require "test_helper"
 
 # Help catch bugs from objects not being marked at all
 # GC opportunities.
 class GCStressTest < Minitest::Test
   def test_compile_and_render
-    source = '{% assign x = 1 %}{% if x -%} x: {{ x | plus: 2 }}{% endif %}'
+    source = "{% assign x = 1 %}{% if x -%} x: {{ x | plus: 2 }}{% endif %}"
     result = gc_stress do
       Liquid::Template.parse(source).render!
     end

--- a/test/unit/raw_test.rb
+++ b/test/unit/raw_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require "test_helper"
 
 class RawTest < Minitest::Test
   class RawWrapper < Liquid::Raw

--- a/test/unit/resource_limits_test.rb
+++ b/test/unit/resource_limits_test.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-require 'test_helper'
+
+require "test_helper"
 
 class ResourceLimitsTest < Minitest::Test
   def test_increment_render_score
@@ -22,7 +23,7 @@ class ResourceLimitsTest < Minitest::Test
 
   def test_increment_write_score
     resource_limits = Liquid::ResourceLimits.new(render_length_limit: 5)
-    output = 'a' * 10
+    output = "a" * 10
     assert_raises(Liquid::MemoryError) do
       resource_limits.increment_write_score(output)
     end
@@ -38,7 +39,7 @@ class ResourceLimitsTest < Minitest::Test
 
   def test_with_capture
     resource_limits = Liquid::ResourceLimits.new(assign_score_limit: 5)
-    output = 'foo'
+    output = "foo"
 
     resource_limits.with_capture do
       resource_limits.increment_write_score(output)

--- a/test/unit/tokenizer_test.rb
+++ b/test/unit/tokenizer_test.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 # frozen_string_literal: true
-require 'test_helper'
+
+require "test_helper"
 
 class TokenizerTest < Minitest::Test
   def test_tokenizer_nil
@@ -9,29 +10,29 @@ class TokenizerTest < Minitest::Test
   end
 
   def test_tokenize_strings
-    assert_equal([' '], tokenize(' '))
-    assert_equal(['hello world'], tokenize('hello world'))
+    assert_equal([" "], tokenize(" "))
+    assert_equal(["hello world"], tokenize("hello world"))
   end
 
   def test_tokenize_variables
-    assert_equal(['{{funk}}'], tokenize('{{funk}}'))
-    assert_equal([' ', '{{funk}}', ' '], tokenize(' {{funk}} '))
-    assert_equal([' ', '{{funk}}', ' ', '{{so}}', ' ', '{{brother}}', ' '], tokenize(' {{funk}} {{so}} {{brother}} '))
-    assert_equal([' ', '{{  funk  }}', ' '], tokenize(' {{  funk  }} '))
+    assert_equal(["{{funk}}"], tokenize("{{funk}}"))
+    assert_equal([" ", "{{funk}}", " "], tokenize(" {{funk}} "))
+    assert_equal([" ", "{{funk}}", " ", "{{so}}", " ", "{{brother}}", " "], tokenize(" {{funk}} {{so}} {{brother}} "))
+    assert_equal([" ", "{{  funk  }}", " "], tokenize(" {{  funk  }} "))
 
     # Doesn't strip whitespace
-    assert_equal([' ', '  funk  ', ' '], tokenize(' {{  funk  }} ', trimmed: true))
+    assert_equal([" ", "  funk  ", " "], tokenize(" {{  funk  }} ", trimmed: true))
   end
 
   def test_tokenize_blocks
-    assert_equal(['{%comment%}'], tokenize('{%comment%}'))
-    assert_equal([' ', '{%comment%}', ' '], tokenize(' {%comment%} '))
+    assert_equal(["{%comment%}"], tokenize("{%comment%}"))
+    assert_equal([" ", "{%comment%}", " "], tokenize(" {%comment%} "))
 
-    assert_equal([' ', '{%comment%}', ' ', '{%endcomment%}', ' '], tokenize(' {%comment%} {%endcomment%} '))
-    assert_equal(['  ', '{% comment %}', ' ', '{% endcomment %}', ' '], tokenize("  {% comment %} {% endcomment %} "))
+    assert_equal([" ", "{%comment%}", " ", "{%endcomment%}", " "], tokenize(" {%comment%} {%endcomment%} "))
+    assert_equal(["  ", "{% comment %}", " ", "{% endcomment %}", " "], tokenize("  {% comment %} {% endcomment %} "))
 
     # Doesn't strip whitespace
-    assert_equal([' ', '  comment  ', ' '], tokenize(' {%  comment  %} ', trimmed: true))
+    assert_equal([" ", "  comment  ", " "], tokenize(" {%  comment  %} ", trimmed: true))
   end
 
   def test_tokenize_for_liquid_tag
@@ -49,7 +50,7 @@ class TokenizerTest < Minitest::Test
   end
 
   def test_utf8_encoded_source
-    source = 'auswählen'
+    source = "auswählen"
     assert_equal(Encoding::UTF_8, source.encoding)
     output = tokenize(source)
     assert_equal([Encoding::UTF_8], output.map(&:encoding))
@@ -57,7 +58,7 @@ class TokenizerTest < Minitest::Test
   end
 
   def test_utf8_compatible_source
-    source = String.new('ascii', encoding: Encoding::ASCII)
+    source = String.new("ascii", encoding: Encoding::ASCII)
     tokenizer = new_tokenizer(source)
     output = tokenizer.send(:shift)
     assert_equal(Encoding::UTF_8, output.encoding)
@@ -66,7 +67,7 @@ class TokenizerTest < Minitest::Test
   end
 
   def test_non_utf8_compatible_source
-    source = 'üñicode'.dup.force_encoding(Encoding::BINARY)
+    source = "üñicode".dup.force_encoding(Encoding::BINARY) # rubocop:disable Performance/UnfreezeString
     exc = assert_raises(Encoding::CompatibilityError) do
       Liquid::C::Tokenizer.new(source, 1, false)
     end

--- a/test/unit/variable_test.rb
+++ b/test/unit/variable_test.rb
@@ -1,41 +1,42 @@
 # encoding: utf-8
 # frozen_string_literal: true
-require 'test_helper'
+
+require "test_helper"
 
 class VariableTest < Minitest::Test
   def test_variable_parse
-    assert_equal('world', variable_strict_parse("hello").render!({ 'hello' => 'world' }))
-    assert_equal('world', variable_strict_parse('"world"').render!)
-    assert_equal('answer', variable_strict_parse('hello["world"]').render!({ 'hello' => { 'world' => "answer" } }))
-    assert_equal('answer', variable_strict_parse('question?').render!({ 'question?' => "answer" }))
-    assert_equal('value', variable_strict_parse('[meta]').render!({ 'meta' => 'key', 'key' => "value" }))
-    assert_equal('result', variable_strict_parse('a-b').render!({ 'a-b' => 'result' }))
-    assert_equal('result', variable_strict_parse('a-2').render!({ 'a-2' => 'result' }))
+    assert_equal("world", variable_strict_parse("hello").render!({ "hello" => "world" }))
+    assert_equal("world", variable_strict_parse('"world"').render!)
+    assert_equal("answer", variable_strict_parse('hello["world"]').render!({ "hello" => { "world" => "answer" } }))
+    assert_equal("answer", variable_strict_parse("question?").render!({ "question?" => "answer" }))
+    assert_equal("value", variable_strict_parse("[meta]").render!({ "meta" => "key", "key" => "value" }))
+    assert_equal("result", variable_strict_parse("a-b").render!({ "a-b" => "result" }))
+    assert_equal("result", variable_strict_parse("a-2").render!({ "a-2" => "result" }))
   end
 
   def test_strictness
     assert_raises(Liquid::SyntaxError) { variable_strict_parse(' hello["world\']" ') }
-    assert_raises(Liquid::SyntaxError) { variable_strict_parse(' -..') }
-    assert_raises(Liquid::SyntaxError) { variable_strict_parse('question?mark') }
-    assert_raises(Liquid::SyntaxError) { variable_strict_parse('123.foo') }
-    assert_raises(Liquid::SyntaxError) { variable_strict_parse(' | nothing') }
+    assert_raises(Liquid::SyntaxError) { variable_strict_parse(" -..") }
+    assert_raises(Liquid::SyntaxError) { variable_strict_parse("question?mark") }
+    assert_raises(Liquid::SyntaxError) { variable_strict_parse("123.foo") }
+    assert_raises(Liquid::SyntaxError) { variable_strict_parse(" | nothing") }
 
-    ['a -b', 'a- b', 'a - b'].each do |var|
+    ["a -b", "a- b", "a - b"].each do |var|
       assert_raises(Liquid::SyntaxError) { variable_strict_parse(var) }
     end
   end
 
   def test_literals
-    assert_equal("", variable_strict_parse('').render!)
-    assert_equal("true", variable_strict_parse('true').render!)
-    assert_equal("", variable_strict_parse('nil').render!)
-    assert_equal("123.4", variable_strict_parse('123.4').render!)
+    assert_equal("", variable_strict_parse("").render!)
+    assert_equal("true", variable_strict_parse("true").render!)
+    assert_equal("", variable_strict_parse("nil").render!)
+    assert_equal("123.4", variable_strict_parse("123.4").render!)
 
-    assert_equal('blank_value', variable_strict_parse('[blank]').render!({ '' => 'blank_value' }))
-    assert_equal('result', variable_strict_parse('[true][blank]').render!({ true => { '' => 'result' } }))
-    assert_equal('result', variable_strict_parse('x["size"]').render!({ 'x' => { 'size' => 'result' } }))
-    assert_equal('result', variable_strict_parse('blank.x').render!({ 'blank' => { 'x' => 'result' } }))
-    assert_equal('result', variable_strict_parse('blank["x"]').render!({ 'blank' => { 'x' => 'result' } }))
+    assert_equal("blank_value", variable_strict_parse("[blank]").render!({ "" => "blank_value" }))
+    assert_equal("result", variable_strict_parse("[true][blank]").render!({ true => { "" => "result" } }))
+    assert_equal("result", variable_strict_parse('x["size"]').render!({ "x" => { "size" => "result" } }))
+    assert_equal("result", variable_strict_parse("blank.x").render!({ "blank" => { "x" => "result" } }))
+    assert_equal("result", variable_strict_parse('blank["x"]').render!({ "blank" => { "x" => "result" } }))
   end
 
   module InspectCallFilters
@@ -55,37 +56,37 @@ class VariableTest < Minitest::Test
   end
 
   def test_variable_filter
-    context = { 'name' => 'Bob' }
+    context = { "name" => "Bob" }
 
-    filter1_output = variable_strict_parse('name | filter1').render!(context, filters: [InspectCallFilters])
+    filter1_output = variable_strict_parse("name | filter1").render!(context, filters: [InspectCallFilters])
     assert_equal('{ filter: :filter1, input: "Bob", args: [] }', filter1_output)
 
-    filter2_output = variable_strict_parse('name | filter1 | filter2').render!(context, filters: [InspectCallFilters])
+    filter2_output = variable_strict_parse("name | filter1 | filter2").render!(context, filters: [InspectCallFilters])
     assert_equal("{ filter: :filter2, input: #{filter1_output.inspect}, args: [] }", filter2_output)
   end
 
   def test_variable_filter_args
-    context = { 'name' => 'Bob', 'abc' => 'xyz' }
+    context = { "name" => "Bob", "abc" => "xyz" }
     render_opts = { filters: [InspectCallFilters] }
 
-    filter1_output = variable_strict_parse('name | filter1: abc').render!(context, render_opts)
+    filter1_output = variable_strict_parse("name | filter1: abc").render!(context, render_opts)
     assert_equal('{ filter: :filter1, input: "Bob", args: ["xyz"] }', filter1_output)
 
-    filter2_output = variable_strict_parse('name | filter1: abc | filter2: abc').render!(context, render_opts)
+    filter2_output = variable_strict_parse("name | filter1: abc | filter2: abc").render!(context, render_opts)
     assert_equal("{ filter: :filter2, input: #{filter1_output.inspect}, args: [\"xyz\"] }", filter2_output)
 
-    context = { 'name' => 'Bob', 'a' => 1, 'c' => 3, 'e' => 5 }
+    context = { "name" => "Bob", "a" => 1, "c" => 3, "e" => 5 }
 
-    output = variable_strict_parse('name | filter1 : a , b : c , d : e').render!(context, render_opts)
+    output = variable_strict_parse("name | filter1 : a , b : c , d : e").render!(context, render_opts)
     assert_equal('{ filter: :filter1, input: "Bob", args: [1, {"b"=>3, "d"=>5}] }', output)
 
     assert_raises(Liquid::SyntaxError) do
-      variable_strict_parse('name | filter : a : b : c : d : e')
+      variable_strict_parse("name | filter : a : b : c : d : e")
     end
   end
 
   def test_unicode_strings
-    string_content = 'å߀êùｉｄｈｔлｓԁѵ߀ｒáƙìｓｔɦｅƅêｓｔｐｃｍáѕｔｅｒｒãｃêｃհèｒｒ'
+    string_content = "å߀êùｉｄｈｔлｓԁѵ߀ｒáƙìｓｔɦｅƅêｓｔｐｃｍáѕｔｅｒｒãｃêｃհèｒｒ"
     assert_equal(string_content, variable_strict_parse("\"#{string_content}\"").render!)
   end
 
@@ -103,30 +104,30 @@ class VariableTest < Minitest::Test
       variable_fallback: lambda { variable_fallbacks += 1 },
     }
 
-    Liquid::Template.parse('{{abc}}', error_mode: :lax, stats_callbacks: callbacks)
+    Liquid::Template.parse("{{abc}}", error_mode: :lax, stats_callbacks: callbacks)
     assert_equal(0, variable_fallbacks)
 
-    Liquid::Template.parse('{{@!#}}', error_mode: :lax, stats_callbacks: callbacks)
+    Liquid::Template.parse("{{@!#}}", error_mode: :lax, stats_callbacks: callbacks)
     assert_equal(1, variable_fallbacks)
   end
 
   def test_write_string
-    output = Liquid::Template.parse("{{ str }}").render({ 'str' => 'foo' })
+    output = Liquid::Template.parse("{{ str }}").render({ "str" => "foo" })
     assert_equal("foo", output)
   end
 
   def test_write_fixnum
-    output = Liquid::Template.parse("{{ num }}").render({ 'num' => 123456 })
+    output = Liquid::Template.parse("{{ num }}").render({ "num" => 123456 })
     assert_equal("123456", output)
   end
 
   def test_write_array
-    output = Liquid::Template.parse("{{ ary }}").render({ 'ary' => ['foo', 123, ['nested', 'ary'], nil, 0.5] })
+    output = Liquid::Template.parse("{{ ary }}").render({ "ary" => ["foo", 123, ["nested", "ary"], nil, 0.5] })
     assert_equal("foo123nestedary0.5", output)
   end
 
   def test_write_nil
-    output = Liquid::Template.parse("{{ obj }}").render({ 'obj' => nil })
+    output = Liquid::Template.parse("{{ obj }}").render({ "obj" => nil })
     assert_equal("", output)
   end
 
@@ -145,14 +146,14 @@ class VariableTest < Minitest::Test
   end
 
   def test_write_to_s_convertible_object
-    output = Liquid::Template.parse("{{ obj }}").render!({ 'obj' => StringConvertible.new('foo') })
+    output = Liquid::Template.parse("{{ obj }}").render!({ "obj" => StringConvertible.new("foo") })
     assert_equal("foo", output)
   end
 
   def test_write_object_with_broken_to_s
     template = Liquid::Template.parse("{{ obj }}")
     exc = assert_raises(TypeError) do
-      template.render!({ 'obj' => StringConvertible.new(123) })
+      template.render!({ "obj" => StringConvertible.new(123) })
     end
     assert_equal(
       "VariableTest::StringConvertible#to_s returned a non-String convertible value of type Integer",
@@ -167,69 +168,69 @@ class VariableTest < Minitest::Test
   end
 
   def test_write_derived_string
-    output = Liquid::Template.parse("{{ obj }}").render!({ 'obj' => DerivedString.new('bar') })
+    output = Liquid::Template.parse("{{ obj }}").render!({ "obj" => DerivedString.new("bar") })
     assert_equal("bar", output)
   end
 
   def test_filter_without_args
-    output = Liquid::Template.parse("{{ var | upcase }}").render({ 'var' => 'Hello' })
+    output = Liquid::Template.parse("{{ var | upcase }}").render({ "var" => "Hello" })
     assert_equal("HELLO", output)
   end
 
   def test_filter_with_const_arg
-    output = Liquid::Template.parse("{{ x | plus: 2 }}").render({ 'x' => 3 })
+    output = Liquid::Template.parse("{{ x | plus: 2 }}").render({ "x" => 3 })
     assert_equal("5", output)
   end
 
   def test_filter_with_variable_arg
-    output = Liquid::Template.parse("{{ x | plus: y }}").render({ 'x' => 10, 'y' => 123 })
+    output = Liquid::Template.parse("{{ x | plus: y }}").render({ "x" => 10, "y" => 123 })
     assert_equal("133", output)
   end
 
   def test_filter_with_variable_arg_after_const_arg
-    output = Liquid::Template.parse("{{ ary | slice: 1, 2 }}").render({ 'ary' => [1, 2, 3, 4] })
+    output = Liquid::Template.parse("{{ ary | slice: 1, 2 }}").render({ "ary" => [1, 2, 3, 4] })
     assert_equal("23", output)
   end
 
   def test_filter_with_const_keyword_arg
-    output = Liquid::Template.parse("{{ value | default: 'None' }}").render({ 'value' => false })
-    assert_equal('None', output)
+    output = Liquid::Template.parse("{{ value | default: 'None' }}").render({ "value" => false })
+    assert_equal("None", output)
 
-    output = Liquid::Template.parse("{{ value | default: 'None', allow_false: true }}").render({ 'value' => false })
-    assert_equal('false', output)
+    output = Liquid::Template.parse("{{ value | default: 'None', allow_false: true }}").render({ "value" => false })
+    assert_equal("false", output)
   end
 
   def test_filter_with_variable_keyword_arg
     template = Liquid::Template.parse("{{ value | default: 'None', allow_false: false_allowed }}")
 
-    assert_equal('None', template.render({ 'value' => false, 'false_allowed' => false }))
-    assert_equal('false', template.render({ 'value' => false, 'false_allowed' => true }))
+    assert_equal("None", template.render({ "value" => false, "false_allowed" => false }))
+    assert_equal("false", template.render({ "value" => false, "false_allowed" => true }))
   end
 
   def test_filter_error
-    output = Liquid::Template.parse("before ({{ ary | concat: 2 }}) after").render({ 'ary' => [1] })
-    assert_equal('before (Liquid error: concat filter requires an array argument) after', output)
+    output = Liquid::Template.parse("before ({{ ary | concat: 2 }}) after").render({ "ary" => [1] })
+    assert_equal("before (Liquid error: concat filter requires an array argument) after", output)
   end
 
   def test_render_variable_object
     variable = Liquid::Variable.new("ary | concat: ary2", Liquid::ParseContext.new)
     assert_instance_of(Liquid::C::VariableExpression, variable.name)
 
-    context = Liquid::Context.new('ary' => [1], 'ary2' => [2])
+    context = Liquid::Context.new("ary" => [1], "ary2" => [2])
     assert_equal([1, 2], variable.render(context))
 
-    context['ary2'] = 2
+    context["ary2"] = 2
     exc = assert_raises(Liquid::ArgumentError) do
       variable.render(context)
     end
-    assert_equal('Liquid error: concat filter requires an array argument', exc.message)
+    assert_equal("Liquid error: concat filter requires an array argument", exc.message)
   end
 
   def test_filter_argument_error_translation
     variable = Liquid::Variable.new("'some words' | split", Liquid::ParseContext.new)
     context = Liquid::Context.new
     exc = assert_raises(Liquid::ArgumentError) { variable.render(context) }
-    assert_equal('Liquid error: wrong number of arguments (given 1, expected 2)', exc.message)
+    assert_equal("Liquid error: wrong number of arguments (given 1, expected 2)", exc.message)
   end
 
   class IntegerDrop < Liquid::Drop
@@ -245,12 +246,12 @@ class VariableTest < Minitest::Test
 
   def test_to_liquid_value_on_variable_lookup
     context = {
-      'number' => IntegerDrop.new('1'),
-      'list' => [1, 2, 3, 4, 5],
+      "number" => IntegerDrop.new("1"),
+      "list" => [1, 2, 3, 4, 5],
     }
 
-    output = variable_strict_parse('list[number]').render!(context)
-    assert_equal('2', output)
+    output = variable_strict_parse("list[number]").render!(context)
+    assert_equal("2", output)
   end
 
   private


### PR DESCRIPTION
### What are you trying to accomplish?

Currently CI is failing due to Rubocop. ([Failed run](https://github.com/Shopify/liquid-c/runs/4833986435?check_suite_focus=true))

The Rubocop violence is coming from the `tmp` folder which we can exclude from Rubocop.

```bash
RuboCop failed!
Running RuboCop...
Inspecting 26 files
.........................C

Offenses:

tmp/x86_64-linux/liquid_c/3.0.3/.rake-compiler-siteconf.rb:1:1: C: Naming/FileName: The name of this source file (.rake-compiler-siteconf.rb) should use snake_case.
require 'rbconfig'
^
tmp/x86_64-linux/liquid_c/3.0.3/.rake-compiler-siteconf.rb:1:1: C: Style/FrozenStringLiteralComment: Missing frozen string literal comment.
require 'rbconfig'
^
```

### How are you solving this issue?

In this PR, it will add a rule to exclude the `tmp` folder from Rubocop.
This PR will be also upgrading the Rubocop since the Rubocop version `0.93.1` is failing to inspect our rake files.

```
bundle exec rubocop
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
Inspecting 25 files
..........An error occurred while Layout/BlockAlignment cop was inspecting /home/michael/liquid-c/rakelib/integration_test.rake:3:0.
To see the complete backtrace run rubocop -d.
..An error occurred while Layout/BlockAlignment cop was inspecting /home/michael/liquid-c/rakelib/rubocop.rake:3:0.
To see the complete backtrace run rubocop -d.
.An error occurred while Layout/BlockAlignment cop was inspecting /home/michael/liquid-c/rakelib/unit_test.rake:3:0.
To see the complete backtrace run rubocop -d.
............

25 files inspected, no offenses detected

3 errors occurred:
An error occurred while Layout/BlockAlignment cop was inspecting /home/michael/liquid-c/rakelib/integration_test.rake:3:0.
An error occurred while Layout/BlockAlignment cop was inspecting /home/michael/liquid-c/rakelib/rubocop.rake:3:0.
An error occurred while Layout/BlockAlignment cop was inspecting /home/michael/liquid-c/rakelib/unit_test.rake:3:0.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
https://github.com/rubocop-hq/rubocop/issues

Mention the following information in the issue report:
0.93.1 (using Parser 3.1.0.0, rubocop-ast 1.15.1, running on ruby 3.1.0 x86_64-linux)
```
