### PR TITLE
Fix test using Ruby 2.7 positional arguments

### DIFF
--- a/test/unit/block_test.rb
+++ b/test/unit/block_test.rb
@@ -115,11 +115,11 @@ class BlockTest < MiniTest::Test
   def test_include_partial_with_syntax_error
     old_file_system = Liquid::Template.file_system
     begin
-      Liquid::Template.file_system = StubFileSystem.new(
+      Liquid::Template.file_system = StubFileSystem.new({
         "invalid" => "{% foo %}",
         "valid" => '{% include "nested" %}',
         "nested" => "valid",
-      )
+      })
 
       template = Liquid::Template.parse("{% include 'invalid' %},{% include 'valid' %}")
       assert_equal("Liquid syntax error: Unknown tag 'foo',valid", template.render)


### PR DESCRIPTION
This was originally fixed in 12537f64176aeea8b0e528520dadfb89f6cb325e
but was accidentally undone in d28a941f9cf5a6ed6a61693ae86234c6734f676d.