### PR TITLE
bump gem version to 4.1.0

### DIFF
--- a/lib/liquid/c/version.rb
+++ b/lib/liquid/c/version.rb
@@ -2,6 +2,6 @@
 
 module Liquid
   module C
-    VERSION = "4.0.0"
+    VERSION = "4.1.0"
   end
 end


### PR DESCRIPTION
With our recent version update, I have forgot to update the version number in `lib/liquid/c/version.rb` 