### PR TITLE
test_helper: skip GC compaction on unsupported platforms

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,7 +8,11 @@ require "liquid/c"
 if GC.respond_to?(:verify_compaction_references)
   # This method was added in Ruby 3.0.0. Calling it this way asks the GC to
   # move objects around, helping to find object movement bugs.
-  GC.verify_compaction_references(double_heap: true, toward: :empty)
+  begin
+    GC.verify_compaction_references(double_heap: true, toward: :empty)
+  rescue NotImplementedError
+    puts "W: GC compaction not suppported by platform"
+  end
 end
 
 GC.stress = true if ENV["GC_STRESS"]


### PR DESCRIPTION
Not all platforms support GC compaction (e.g. 64-bit little endian PowerPC, ppc64el on Debian/Ubuntu). Handling NotImplementedError when enabling it allows us to run the test suite on those platforms.