### PR TITLE
Fix crashes with auto-compaction

### DIFF
--- a/.github/workflows/liquid.yml
+++ b/.github/workflows/liquid.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0'
+          ruby-version: '3.1'
       - run: sudo apt-get install -y valgrind
       - uses: actions/cache@v1
         with:

--- a/.github/workflows/liquid.yml
+++ b/.github/workflows/liquid.yml
@@ -8,6 +8,7 @@ jobs:
         entry:
           - { ruby: '2.7', allowed-failure: false }
           - { ruby: '3.0', allowed-failure: false }
+          - { ruby: '3.1', allowed-failure: false }
           - { ruby: ruby-head, allowed-failure: true }
     name: test (${{ matrix.entry.ruby }})
     steps:

--- a/ext/liquid_c/block.c
+++ b/ext/liquid_c/block.c
@@ -49,7 +49,7 @@ static void block_body_mark(void *ptr)
     } else {
         rb_gc_mark(body->as.intermediate.parse_context);
         if (body->as.intermediate.vm_assembler_pool)
-            vm_assembler_pool_gc_mark(body->as.intermediate.vm_assembler_pool);
+            rb_gc_mark(body->as.intermediate.vm_assembler_pool->self);
         if (body->as.intermediate.code)
             vm_assembler_gc_mark(body->as.intermediate.code);
     }

--- a/ext/liquid_c/document_body.c
+++ b/ext/liquid_c/document_body.c
@@ -9,6 +9,14 @@ static VALUE cLiquidCDocumentBody;
 static void document_body_mark(void *ptr)
 {
     document_body_t *body = ptr;
+    /* When Liquid::C::BlockBody#freeze is called, it calls
+     * document_body_write_block_body which sets the document_body_entry but
+     * does not yet set the compiled flag to true. During this time, the only
+     * reference to this Liquid::C::DocumentBody object is in the instance
+     * variables of the parse_context which is marked movable by Ruby. This
+     * causes the self reference here to be moved by compaction causing it to
+     * point to an incorrect object. */
+    rb_gc_mark(body->self);
     rb_gc_mark(body->constants);
 }
 

--- a/ext/liquid_c/vm_assembler_pool.c
+++ b/ext/liquid_c/vm_assembler_pool.c
@@ -3,8 +3,10 @@
 
 static VALUE cLiquidCVMAssemblerPool;
 
-void vm_assembler_pool_gc_mark(vm_assembler_pool_t *pool)
+static void vm_assembler_pool_mark(void *ptr)
 {
+    vm_assembler_pool_t *pool = ptr;
+
     rb_gc_mark(pool->self);
 }
 
@@ -39,7 +41,7 @@ static size_t vm_assembler_pool_memsize(const void *ptr)
 
 const rb_data_type_t vm_assembler_pool_data_type = {
     "liquid_vm_assembler_pool",
-    { NULL, vm_assembler_pool_free, vm_assembler_pool_memsize, },
+    { vm_assembler_pool_mark, vm_assembler_pool_free, vm_assembler_pool_memsize, },
     NULL, NULL, RUBY_TYPED_FREE_IMMEDIATELY
 };
 

--- a/ext/liquid_c/vm_assembler_pool.h
+++ b/ext/liquid_c/vm_assembler_pool.h
@@ -18,7 +18,6 @@ extern const rb_data_type_t vm_assembler_pool_data_type;
 #define VMAssemblerPool_Get_Struct(obj, sval) TypedData_Get_Struct(obj, vm_assembler_pool_t, &vm_assembler_pool_data_type, sval)
 
 void liquid_define_vm_assembler_pool(void);
-void vm_assembler_pool_gc_mark(vm_assembler_pool_t *pool);
 VALUE vm_assembler_pool_new(void);
 vm_assembler_t *vm_assembler_pool_alloc_assembler(vm_assembler_pool_t *pool);
 void vm_assembler_pool_free_assembler(vm_assembler_t *assembler);

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,4 +15,9 @@ if GC.respond_to?(:verify_compaction_references)
   end
 end
 
+# Enable auto-compaction in the GC if supported.
+if GC.respond_to?(:auto_compact=)
+  GC.auto_compact = true
+end
+
 GC.stress = true if ENV["GC_STRESS"]


### PR DESCRIPTION
See commit messages for details.

The crash can be seen in [this buildkite build](https://buildkite.com/shopify/shopify-ruby-head/builds/27171#0183a9aa-139d-4d8f-b562-2ff177f130b1) or by turning on auto-compaction in the test suite.