### PR TITLE
Remove GC.start required by ruby_memcheck

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-at_exit { GC.start }
-
 require "minitest/autorun"
 require "liquid/c"
 


### PR DESCRIPTION
As of version 1.2.0, ruby_memcheck no longer needs the call to GC.start at exit. It will do it automatically.