### PR TITLE
Enable assertions when DEBUG=true

### DIFF
--- a/ext/liquid_c/extconf.rb
+++ b/ext/liquid_c/extconf.rb
@@ -12,6 +12,10 @@ end
 if ENV["DEBUG"] == "true"
   append_cflags("-fbounds-check")
   CONFIG["optflags"] = " -O0"
+  # Hack to enable assertions since ruby/assert.h disables assertions unless
+  # Ruby was compiled with -DRUBY_DEBUG.
+  # https://github.com/ruby/ruby/blob/9e678cdbd054f78576a8f21b3f97cccc395ade22/include/ruby/assert.h#L36-L41
+  $CFLAGS << " -DRUBY_DEBUG"
 else
   $CFLAGS << " -DNDEBUG"
 end


### PR DESCRIPTION
[ruby/assert.h](https://github.com/ruby/ruby/blob/9e678cdbd054f78576a8f21b3f97cccc395ade22/include/ruby/assert.h#L36-L41) disables assertions if Ruby was not compiled with `-DRUBY_DEBUG`. We can force assertions to be ran by explicitly setting `-DRUBY_DEBUG`.