### PR TITLE
Renable assert in development after ruby intentionally disabled it

### DIFF
--- a/ext/liquid_c/c_buffer.h
+++ b/ext/liquid_c/c_buffer.h
@@ -1,7 +1,7 @@
 #ifndef LIQUID_C_BUFFER_H
 #define LIQUID_C_BUFFER_H
 
-#include <ruby.h>
+#include "ruby_with_assert.h"
 
 typedef struct c_buffer {
     uint8_t *data;

--- a/ext/liquid_c/document_body.c
+++ b/ext/liquid_c/document_body.c
@@ -1,4 +1,3 @@
-#include <ruby.h>
 #include <stdalign.h>
 #include "liquid.h"
 #include "vm_assembler.h"

--- a/ext/liquid_c/liquid.h
+++ b/ext/liquid_c/liquid.h
@@ -1,7 +1,7 @@
 #if !defined(LIQUID_H)
 #define LIQUID_H
 
-#include <ruby.h>
+#include "ruby_with_assert.h"
 #include <ruby/encoding.h>
 #include <stdbool.h>
 

--- a/ext/liquid_c/parse_context.h
+++ b/ext/liquid_c/parse_context.h
@@ -1,7 +1,7 @@
 #ifndef LIQUID_PARSE_CONTEXT_H
 #define LIQUID_PARSE_CONTEXT_H
 
-#include <ruby.h>
+#include "ruby_with_assert.h"
 #include <stdbool.h>
 #include "vm_assembler_pool.h"
 

--- a/ext/liquid_c/ruby_with_assert.h
+++ b/ext/liquid_c/ruby_with_assert.h
@@ -1,0 +1,14 @@
+#if !defined(RUBY_WITH_ASSERT_H)
+#define RUBY_WITH_ASSERT_H
+
+// Workaround for ruby disabling assertions (https://bugs.ruby-lang.org/issues/18777)
+#ifdef NDEBUG
+#include <ruby.h>
+#else
+#include <ruby.h>
+#undef NDEBUG
+#endif
+// DO NOT MOVE. If assert.h is included before ruby.h asserts will turn to no-op.
+#include <assert.h>
+
+#endif

--- a/ext/liquid_c/tokenizer.c
+++ b/ext/liquid_c/tokenizer.c
@@ -1,4 +1,3 @@
-#include <assert.h>
 #include "liquid.h"
 #include "tokenizer.h"
 #include "stringutil.h"

--- a/ext/liquid_c/vm.c
+++ b/ext/liquid_c/vm.c
@@ -1,5 +1,4 @@
 #include <stdint.h>
-#include <assert.h>
 
 #include "liquid.h"
 #include "vm.h"

--- a/ext/liquid_c/vm.h
+++ b/ext/liquid_c/vm.h
@@ -1,7 +1,7 @@
 #ifndef VM_H
 #define VM_H
 
-#include <ruby.h>
+#include "ruby_with_assert.h"
 #include "block.h"
 #include "vm_assembler.h"
 #include "context.h"

--- a/ext/liquid_c/vm_assembler.h
+++ b/ext/liquid_c/vm_assembler.h
@@ -1,7 +1,6 @@
 #ifndef VM_ASSEMBLER_H
 #define VM_ASSEMBLER_H
 
-#include <assert.h>
 #include "liquid.h"
 #include "c_buffer.h"
 #include "intutil.h"


### PR DESCRIPTION
Closes #193

I found https://bugs.ruby-lang.org/issues/18777 which specifically reported this issue upstream, where it was indeed closed as being intentional behaviour.  However, the reporter of the issue did post a workaround of wrapping the include to ruby.h to `#undef NDEBUG` if it wasn't set before the include.  That seems like a more targeted fix for the problem than #193, although still an unfortunate hack.