### PR TITLE
Rename MiniTest to Minitest

### DIFF
--- a/test/unit/block_test.rb
+++ b/test/unit/block_test.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class BlockTest < MiniTest::Test
+class BlockTest < Minitest::Test
   def test_no_allocation_of_trimmed_strings
     template = Liquid::Template.parse("{{ a -}}     {{- b }}")
     assert_equal(2, template.root.nodelist.size)

--- a/test/unit/expression_test.rb
+++ b/test/unit/expression_test.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class ExpressionTest < MiniTest::Test
+class ExpressionTest < Minitest::Test
   def test_constant_literals
     assert_equal(true, Liquid::C::Expression.strict_parse("true"))
     assert_equal(false, Liquid::C::Expression.strict_parse("false"))


### PR DESCRIPTION
MiniTest namespace was deprecated and support removed in minitest 5.19.0.