### PR TITLE
Use Ruby head for Valgrind CI

### DIFF
--- a/.github/workflows/liquid.yml
+++ b/.github/workflows/liquid.yml
@@ -34,7 +34,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          # We have to use Ruby head until Ruby 3.3 is released due to https://bugs.ruby-lang.org/issues/19436
+          ruby-version: ruby-head
       - run: sudo apt-get install -y valgrind
       - uses: actions/cache@v1
         with:


### PR DESCRIPTION
We need to use Ruby head for Valgrind CI until [Feature #19436](https://bugs.ruby-lang.org/issues/19436) is released in Ruby 3.3.