### PR TITLE
Use Ruby 3.2 for Valgrind tests

### DIFF
--- a/.github/workflows/liquid.yml
+++ b/.github/workflows/liquid.yml
@@ -34,8 +34,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          # We have to use Ruby head until Ruby 3.3 is released due to https://bugs.ruby-lang.org/issues/19436
-          ruby-version: ruby-head
+          ruby-version: 3.2
       - run: sudo apt-get install -y valgrind
       - uses: actions/cache@v1
         with:


### PR DESCRIPTION
The change in #204 did not fix the test failures. The new version (2.1.1) of ruby_memcheck has the fix in
Shopify/ruby_memcheck@7dc2094178cba709e90f871a14510a34873ad827.