### PR TITLE
allow extra string after raw tag delimiter

### DIFF
--- a/test/unit/raw_test.rb
+++ b/test/unit/raw_test.rb
@@ -30,6 +30,14 @@ class RawTest < Minitest::Test
     end
   end
 
+  def test_allows_extra_string_after_tag_delimiter
+    output = Liquid::Template.parse("{% raw %}message{% endraw this_is_allowed %}").render
+    assert_equal("message", output)
+
+    output = Liquid::Template.parse("{% raw %}message{%   endraw r%}").render
+    assert_equal("message", output)
+  end
+
   def test_ignores_incomplete_tag_delimter
     output = Liquid::Template.parse("{% raw %}{% endraw {% endraw %}").render
     assert_equal("{% endraw ", output)
@@ -55,6 +63,7 @@ class RawTest < Minitest::Test
     Liquid::Template.parse("{% raw %}body{% endraw\u00A0 %}")
     Liquid::Template.parse("{% raw %}body{% endraw \u00A0 %}")
     Liquid::Template.parse("{% raw %}body{% endraw \u00A0 endraw %}")
+    Liquid::Template.parse("{% raw %}body{% endraw\u00A0endraw %}")
 
     [
       "{%\u00A0endraw%}",
@@ -63,6 +72,7 @@ class RawTest < Minitest::Test
       "{% \u00A0 endraw%}",
       "{%\u00A0endraw\u00A0%}",
       "{% - endraw %}",
+      "{% endnot endraw %}",
     ].each do |bad_delimiter|
       exception = assert_raises(
         Liquid::SyntaxError,


### PR DESCRIPTION
### What are you trying to solve?

This PR https://github.com/Shopify/liquid-c/pull/200 has broke how Liquid-C parses the raw tag's delimiter with extra string after the tag delimiter.

`raw` tag delimiter like this should be allowed, but Liquid-C is raising a syntax error:
```liquid
{% raw %}
  message
{% endraw this_is_allowed %}
```

### How are you solving this?

Following the Liquid's `raw` [tag delimiter regex](https://github.com/Shopify/liquid/blob/master/lib/liquid/tags/raw.rb#L17), I have updated the Liquid-C's raw tag delimiter to allow extra string after a valid tag delimiter string.

`match_full_token_possibly_invalid` scans the token string backward, and when it finds a word character after a whitespace character, it will reset its last match.