### PR TITLE
Update documentation to suggest use of `main` branch instead of `master`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Liquid::C
-[![Build Status](https://travis-ci.org/Shopify/liquid-c.svg?branch=master)](https://travis-ci.org/Shopify/liquid-c)
+[![Build Status](https://travis-ci.org/Shopify/liquid-c.svg?branch=main)](https://travis-ci.org/Shopify/liquid-c)
 
 Partial native implementation of the liquid ruby gem in C.
 
@@ -7,8 +7,8 @@ Partial native implementation of the liquid ruby gem in C.
 
 Add these lines to your application's Gemfile:
 
-    gem 'liquid', github: 'Shopify/liquid', branch: 'master'
-    gem 'liquid-c', github: 'Shopify/liquid-c', branch: 'master'
+    gem 'liquid', github: 'Shopify/liquid', branch: 'main'
+    gem 'liquid-c', github: 'Shopify/liquid-c', branch: 'main'
 
 And then execute:
 


### PR DESCRIPTION
After this I will update the default branch to be `main`, and push a final commit to the `master` branch mentioning that it has been deprecated.