### PR TITLE
Release 4.2.0

### DIFF
--- a/.github/workflows/liquid.yml
+++ b/.github/workflows/liquid.yml
@@ -9,6 +9,8 @@ jobs:
           - { ruby: '2.7', allowed-failure: false }
           - { ruby: '3.0', allowed-failure: false }
           - { ruby: '3.1', allowed-failure: false }
+          - { ruby: '3.2', allowed-failure: false }
+          - { ruby: '3.3', allowed-failure: false }
           - { ruby: ruby-head, allowed-failure: true }
           - { ruby: truffleruby-head, allowed-failure: true }
     name: test (${{ matrix.ruby }})
@@ -40,7 +42,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: 3.3
           bundler-cache: true
       - run: sudo apt-get install -y valgrind
       - run: bundle exec rake test:valgrind

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gemspec
 gem "liquid", github: "Shopify/liquid", ref: "master"
 
 group :test do
+  gem "base64", require: false # for older rubocop on Ruby 3.4
   gem "rubocop", "~> 1.24.1", require: false
   gem "rubocop-performance", "~> 1.13.2", require: false
   gem "rubocop-shopify", "~> 2.4.0", require: false

--- a/lib/liquid/c/version.rb
+++ b/lib/liquid/c/version.rb
@@ -2,6 +2,6 @@
 
 module Liquid
   module C
-    VERSION = "4.1.0"
+    VERSION = "4.2.0"
   end
 end


### PR DESCRIPTION
Ref: https://github.com/Shopify/liquid-c/pull/211

I don't have a lot of context with `liquic-c`, but based on the README it seems users are epxected to track the git gem anyway?

This release would be useful for the `yjit-bench` project.

@ggmichaelgo you seem to be the owner, is this OK with you?