### PR TITLE
Revert "contextualize value before invoking to_liquid"

### DIFF
--- a/ext/liquid_c/context.h
+++ b/ext/liquid_c/context.h
@@ -44,16 +44,12 @@ inline static VALUE value_to_liquid_and_set_context(VALUE value, VALUE context_t
     if (klass == rb_cString || klass == rb_cArray || klass == rb_cHash)
         return value;
 
-    // set value's context before invoking #to_liquid
+    value = rb_funcall(value, id_to_liquid, 0);
+
     if (rb_respond_to(value, id_set_context))
         rb_funcall(value, id_set_context, 1, context_to_set);
 
-    VALUE liquid_value = rb_funcall(value, id_to_liquid, 0);
-
-    if (liquid_value != value && rb_respond_to(liquid_value, id_set_context))
-        rb_funcall(liquid_value, id_set_context, 1, context_to_set);
-
-    return liquid_value;
+    return value;
 }
 
 


### PR DESCRIPTION
This reverts commit ceec9cd4a41cd79eb36615daa0bbd317ffea5fbc.

This is causing test failures.