### PR TITLE
Update utf-8 validity tests to account for liquid checking encoding

### DIFF
--- a/test/unit/variable_test.rb
+++ b/test/unit/variable_test.rb
@@ -288,40 +288,40 @@ class VariableTest < Minitest::Test
 
   def test_invalid_utf8_sequence
     # 2 byte character with 1 byte missing
-    exc = assert_raises(ArgumentError) do
+    exc = assert_raises(Liquid::TemplateEncodingError) do
       variable_strict_parse("\xC0")
     end
-    assert_equal("invalid byte sequence in UTF-8", exc.message)
+    assert_equal("Liquid error: Invalid template encoding", exc.message)
 
     # 3 byte character with 1 byte missing
-    exc = assert_raises(ArgumentError) do
+    exc = assert_raises(Liquid::TemplateEncodingError) do
       variable_strict_parse("\xE0\x01")
     end
-    assert_equal("invalid byte sequence in UTF-8", exc.message)
+    assert_equal("Liquid error: Invalid template encoding", exc.message)
 
     # 3 byte character with 2 byte missing
-    exc = assert_raises(ArgumentError) do
+    exc = assert_raises(Liquid::TemplateEncodingError) do
       variable_strict_parse("\xE0")
     end
-    assert_equal("invalid byte sequence in UTF-8", exc.message)
+    assert_equal("Liquid error: Invalid template encoding", exc.message)
 
     # 4 byte character with 1 byte missing
-    exc = assert_raises(ArgumentError) do
+    exc = assert_raises(Liquid::TemplateEncodingError) do
       variable_strict_parse("\xF0\x01\x01")
     end
-    assert_equal("invalid byte sequence in UTF-8", exc.message)
+    assert_equal("Liquid error: Invalid template encoding", exc.message)
 
     # 4 byte character with 2 byte missing
-    exc = assert_raises(ArgumentError) do
+    exc = assert_raises(Liquid::TemplateEncodingError) do
       variable_strict_parse("\xF0\x01")
     end
-    assert_equal("invalid byte sequence in UTF-8", exc.message)
+    assert_equal("Liquid error: Invalid template encoding", exc.message)
 
     # 4 byte character with 3 byte missing
-    exc = assert_raises(ArgumentError) do
+    exc = assert_raises(Liquid::TemplateEncodingError) do
       variable_strict_parse("\xF0")
     end
-    assert_equal("invalid byte sequence in UTF-8", exc.message)
+    assert_equal("Liquid error: Invalid template encoding", exc.message)
   end
 
   private


### PR DESCRIPTION
https://github.com/Shopify/liquid/pull/1774 introduced a pre-parsing check for valid UTF-8 encoding, and https://github.com/Shopify/liquid/pull/1776 changed the raised exception to `Liquid::TemplateEncodingError`. This updates the failing test to look for the proper exception and message.

It may also be a valid outcome to remove this test entirely since this behavior is really part of https://github.com/Shopify/liquid and not the c extension