### PR TITLE
remove invalid UTF-8 byte seqeunce tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ end
 
 gemspec
 
-gem "liquid", github: "Shopify/liquid", ref: "master"
+gem "liquid", github: "Shopify/liquid", ref: "main"
 
 group :test do
   gem "base64", require: false # for older rubocop on Ruby 3.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/Shopify/liquid.git
-  revision: 0b9318222bcc09681e52fd5b8e70262274e673bf
-  ref: master
+  revision: 77bc56a1c28a707c2b222559ffb0b7b1c5588928
+  ref: main
   specs:
-    liquid (5.4.0)
+    liquid (5.5.0)
 
 PATH
   remote: .

--- a/test/unit/variable_test.rb
+++ b/test/unit/variable_test.rb
@@ -286,44 +286,6 @@ class VariableTest < Minitest::Test
     )
   end
 
-  def test_invalid_utf8_sequence
-    # 2 byte character with 1 byte missing
-    exc = assert_raises(ArgumentError) do
-      variable_strict_parse("\xC0")
-    end
-    assert_equal("invalid byte sequence in UTF-8", exc.message)
-
-    # 3 byte character with 1 byte missing
-    exc = assert_raises(ArgumentError) do
-      variable_strict_parse("\xE0\x01")
-    end
-    assert_equal("invalid byte sequence in UTF-8", exc.message)
-
-    # 3 byte character with 2 byte missing
-    exc = assert_raises(ArgumentError) do
-      variable_strict_parse("\xE0")
-    end
-    assert_equal("invalid byte sequence in UTF-8", exc.message)
-
-    # 4 byte character with 1 byte missing
-    exc = assert_raises(ArgumentError) do
-      variable_strict_parse("\xF0\x01\x01")
-    end
-    assert_equal("invalid byte sequence in UTF-8", exc.message)
-
-    # 4 byte character with 2 byte missing
-    exc = assert_raises(ArgumentError) do
-      variable_strict_parse("\xF0\x01")
-    end
-    assert_equal("invalid byte sequence in UTF-8", exc.message)
-
-    # 4 byte character with 3 byte missing
-    exc = assert_raises(ArgumentError) do
-      variable_strict_parse("\xF0")
-    end
-    assert_equal("invalid byte sequence in UTF-8", exc.message)
-  end
-
   private
 
   def variable_strict_parse(markup)


### PR DESCRIPTION
### What are you trying to solve?
Liquid has been update to no longer accept templates with invalid UTF-8 byte sequence.([Liquid Update PR](https://github.com/Shopify/liquid/pull/1776#issuecomment-2035050546))

Therefore, we can remove the unit tests that were testing with invalid byte sequence templates.