### PR TITLE
Fix type of struct value

### DIFF
--- a/ext/liquid_c/liquid_vm.c
+++ b/ext/liquid_c/liquid_vm.c
@@ -194,7 +194,7 @@ static VALUE vm_invoke_filter(vm_t *vm, VALUE filter_name, size_t num_args)
 typedef struct vm_render_until_error_args {
     vm_t *vm;
     const uint8_t *ip; // use for initial address and to save an address for rescuing
-    const size_t *const_ptr;
+    const VALUE *const_ptr;
 
     /* rendering fields */
     VALUE output;


### PR DESCRIPTION
The current type for const_ptr is causing builds with Debian's GCC to
fail on 32-bit architectures, because it is being used as `VALUE *` but
is defined as `size_t *`.
